### PR TITLE
refactor: replace convex-helpers with fluent-convex

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -328,7 +328,7 @@
         "@init/utils": "workspace:*",
         "@tanstack/react-query": "^5.90.20",
         "convex": "1.31.6",
-        "convex-helpers": "0.1.111",
+        "fluent-convex": "0.12.3",
         "qte": "0.1.0",
         "std-env": "3.10.0",
       },
@@ -3159,6 +3159,8 @@
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
 
     "flow-enums-runtime": ["flow-enums-runtime@0.0.6", "", {}, "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw=="],
+
+    "fluent-convex": ["fluent-convex@0.12.3", "", { "peerDependencies": { "convex": "^1.31.0", "convex-helpers": ">=0.1.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["convex-helpers", "zod"] }, "sha512-z3mYifNVUZJu8ZpXioZMS9vAU/dcUefVwD1hB1Z6aG1cT3hfwptB5PEXOItFRR2dMBrYJ00Hty9p2OI3PixX/A=="],
 
     "fontace": ["fontace@0.4.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-moThBCItUe2bjZip5PF/iZClpKHGLwMvR79Kp8XpGRBrvoRSnySN4VcILdv3/MJzbhvUA5WeiUXF5o538m5fvg=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -31,7 +31,7 @@
     "@init/utils": "workspace:*",
     "@tanstack/react-query": "^5.90.20",
     "convex": "1.31.6",
-    "convex-helpers": "0.1.111",
+    "fluent-convex": "0.12.3",
     "qte": "0.1.0",
     "std-env": "3.10.0"
   },

--- a/packages/backend/src/functions/_generated/api.d.ts
+++ b/packages/backend/src/functions/_generated/api.d.ts
@@ -8,15 +8,18 @@
  * @module
  */
 
+import type * as auth from "../auth.js";
 import type * as crons from "../crons.js";
 import type * as http from "../http.js";
+import type * as models_documents from "../models/documents.js";
 import type * as private_users from "../private/users.js";
+import type * as public_auth from "../public/auth.js";
 import type * as public_documents from "../public/documents.js";
 import type * as public_messages from "../public/messages.js";
-import type * as shared_auth_index from "../shared/auth/index.js";
-import type * as shared_auth_options from "../shared/auth/options.js";
+import type * as shared_auth from "../shared/auth.js";
 import type * as shared_convex from "../shared/convex.js";
 import type * as shared_env from "../shared/env.js";
+import type * as system_health from "../system/health.js";
 
 import type {
   ApiFromModules,
@@ -25,15 +28,18 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
   crons: typeof crons;
   http: typeof http;
+  "models/documents": typeof models_documents;
   "private/users": typeof private_users;
+  "public/auth": typeof public_auth;
   "public/documents": typeof public_documents;
   "public/messages": typeof public_messages;
-  "shared/auth/index": typeof shared_auth_index;
-  "shared/auth/options": typeof shared_auth_options;
+  "shared/auth": typeof shared_auth;
   "shared/convex": typeof shared_convex;
   "shared/env": typeof shared_env;
+  "system/health": typeof system_health;
 }>;
 
 /**
@@ -63,7 +69,7 @@ export declare const internal: FilterApi<
 >;
 
 export declare const components: {
-  betterAuth: {
+  auth: {
     adapter: {
       create: FunctionReference<
         "mutation",

--- a/packages/backend/src/functions/auth.ts
+++ b/packages/backend/src/functions/auth.ts
@@ -1,12 +1,16 @@
 import type { GenericCtx } from "@convex-dev/better-auth"
 import { createAuth } from "@init/auth/server"
 import type { DataModel } from "#functions/_generated/dataModel.js"
-import { authOptions } from "#functions/shared/auth/options.ts"
+import { authComponent, createAuthOptions } from "#functions/shared/auth.ts"
 import env from "#functions/shared/env.ts"
+
+export { authComponent } from "#functions/shared/auth.ts"
+
+export const { onCreate, onDelete, onUpdate } = authComponent.triggersApi()
 
 export const convexAuth = (ctx: GenericCtx<DataModel>) =>
   createAuth({
-    ...authOptions(ctx),
+    ...createAuthOptions(ctx),
     baseURL: env.CONVEX_SITE_URL,
     secret: env.AUTH_SECRET,
     trustedOrigins: env.AUTH_TRUSTED_ORIGINS,

--- a/packages/backend/src/functions/components/better-auth/adapter.ts
+++ b/packages/backend/src/functions/components/better-auth/adapter.ts
@@ -1,6 +1,6 @@
 import { createApi } from "@convex-dev/better-auth"
-import schema from "#functions/components/better-auth/schema.ts"
-import { authOptions } from "#functions/shared/auth/options.ts"
+import { createAuthOptions } from "#functions/shared/auth.ts"
+import schema from "./schema"
 
 export const { create, findOne, findMany, updateOne, updateMany, deleteOne, deleteMany } =
-  createApi(schema, authOptions)
+  createApi(schema, createAuthOptions)

--- a/packages/backend/src/functions/components/better-auth/auth.ts
+++ b/packages/backend/src/functions/components/better-auth/auth.ts
@@ -1,11 +1,9 @@
 import type { GenericCtx } from "@convex-dev/better-auth"
 import { createAuth } from "@init/auth/server"
 import type { DataModel } from "#functions/_generated/dataModel.js"
-import { authOptions } from "#functions/shared/auth/options.ts"
+import { createAuthOptions } from "#functions/shared/auth.ts"
 
-// Export a static instance for Better Auth schema generation
+// Static instance for Better Auth schema generation only
 export const auth = createAuth({
-  // Casting as GenericCtx<DataModel> since the Convex component does not need
-  // the running context
-  ...authOptions({} as GenericCtx<DataModel>),
+  ...createAuthOptions({} as GenericCtx<DataModel>),
 })

--- a/packages/backend/src/functions/components/better-auth/convex.config.ts
+++ b/packages/backend/src/functions/components/better-auth/convex.config.ts
@@ -1,5 +1,5 @@
 import { defineComponent } from "convex/server"
 
-const component = defineComponent("betterAuth")
+const component = defineComponent("auth")
 
 export default component

--- a/packages/backend/src/functions/components/better-auth/schema.ts
+++ b/packages/backend/src/functions/components/better-auth/schema.ts
@@ -1,4 +1,4 @@
 import { defineSchema } from "convex/server"
 import { tables } from "#functions/components/better-auth/schema.generated.ts"
 
-export default defineSchema({ ...tables })
+export default defineSchema({ ...tables, user: tables.user.index("by_email", ["email"]) })

--- a/packages/backend/src/functions/http.ts
+++ b/packages/backend/src/functions/http.ts
@@ -1,9 +1,13 @@
 import { httpRouter } from "convex/server"
-import { convexAuth } from "#functions/shared/auth/index.ts"
-import { authComponent } from "#functions/shared/auth/options.ts"
+import { authComponent, convexAuth } from "#functions/auth.ts"
+import env from "#functions/shared/env.ts"
 
 const http = httpRouter()
 
-authComponent.registerRoutes(http, convexAuth)
+authComponent.registerRoutes(http, convexAuth, {
+  cors: {
+    allowedOrigins: env.AUTH_TRUSTED_ORIGINS,
+  },
+})
 
 export default http

--- a/packages/backend/src/functions/models/documents.ts
+++ b/packages/backend/src/functions/models/documents.ts
@@ -1,0 +1,29 @@
+import { UnauthenticatedError } from "@init/error"
+import { v } from "convex/values"
+import { protectedQuery, publicQuery } from "#functions/shared/convex.ts"
+
+export const getDocument = publicQuery
+  .input({ name: v.string() })
+  .handler(async (ctx, { name }) => {
+    const document = await ctx.db
+      .query("documents")
+      .withIndex("by_name", (q) => q.eq("name", name))
+      .unique()
+
+    return document
+  })
+
+export const withDocument = protectedQuery.createMiddleware(async (ctx, next) => {
+  const identity = await ctx.auth.getUserIdentity()
+
+  if (!identity) {
+    throw new UnauthenticatedError()
+  }
+
+  const document = await ctx.db
+    .query("documents")
+    .withIndex("by_name", (q) => q.eq("name", identity.subject))
+    .unique()
+
+  return next({ ...ctx, document })
+})

--- a/packages/backend/src/functions/private/users.ts
+++ b/packages/backend/src/functions/private/users.ts
@@ -1,14 +1,12 @@
 import type { UserWithRole } from "@init/auth/server/plugins"
-import { convexAuth } from "#functions/shared/auth/index.ts"
-import { authComponent } from "#functions/shared/auth/options.ts"
+import { authComponent, convexAuth } from "#functions/auth.ts"
 import { privateQuery } from "#functions/shared/convex.ts"
 
-export const list = privateQuery({
-  handler: async (ctx) => {
+export const list = privateQuery
+  .handler(async (ctx) => {
     const { auth, headers } = await authComponent.getAuth(convexAuth, ctx)
-
     const result = await auth.api.listUsers({ headers, query: { limit: 100 } })
 
     return result.users as UserWithRole[]
-  },
-})
+  })
+  .public()

--- a/packages/backend/src/functions/public/auth.ts
+++ b/packages/backend/src/functions/public/auth.ts
@@ -1,0 +1,10 @@
+import { authComponent } from "#functions/shared/auth.ts"
+import { publicQuery } from "#functions/shared/convex.ts"
+
+export const getCurrentUser = publicQuery
+  .handler(async (ctx) => {
+    const user = await authComponent.getAuthUser(ctx)
+
+    return user ?? null
+  })
+  .public()

--- a/packages/backend/src/functions/public/documents.ts
+++ b/packages/backend/src/functions/public/documents.ts
@@ -1,5 +1,5 @@
 import { publicQuery } from "#functions/shared/convex.ts"
 
-export const list = publicQuery({
-  handler: async (ctx) => await ctx.db.query("documents").collect(),
-})
+export const list = publicQuery
+  .handler(async (ctx) => await ctx.db.query("documents").collect())
+  .public()

--- a/packages/backend/src/functions/public/messages.ts
+++ b/packages/backend/src/functions/public/messages.ts
@@ -1,10 +1,13 @@
-import { publicQuery, vv } from "#functions/shared/convex.ts"
+import { v } from "convex/values"
+import { publicQuery } from "#functions/shared/convex.ts"
 
-export const list = publicQuery({
-  args: { documentId: vv.id("documents") },
-  handler: async (ctx, args) =>
-    await ctx.db
-      .query("messages")
-      .withIndex("by_document_id", (q) => q.eq("documentId", args.documentId))
-      .collect(),
-})
+export const list = publicQuery
+  .input({ documentId: v.id("documents") })
+  .handler(
+    async (ctx, args) =>
+      await ctx.db
+        .query("messages")
+        .withIndex("by_document_id", (q) => q.eq("documentId", args.documentId))
+        .collect()
+  )
+  .public()

--- a/packages/backend/src/functions/shared/auth.ts
+++ b/packages/backend/src/functions/shared/auth.ts
@@ -1,7 +1,4 @@
-// Separated this from the main auth.ts file to avoid environment variable
-// errors when trying to use the auth options inside the better auth component..
-
-import type { GenericCtx } from "@convex-dev/better-auth"
+import type { AuthFunctions, GenericCtx } from "@convex-dev/better-auth"
 import type { AuthOptions } from "@init/auth/server"
 import { createClient } from "@convex-dev/better-auth"
 import { convex } from "@convex-dev/better-auth/plugins"
@@ -9,15 +6,18 @@ import { admin, anonymous, organization } from "@init/auth/server/plugins"
 import { APP_ID, APP_NAME } from "@init/utils/constants"
 import { seconds } from "qte"
 import type { DataModel } from "#functions/_generated/dataModel.js"
-import { components } from "#functions/_generated/api.js"
+import { components, internal } from "#functions/_generated/api.js"
 import authConfig from "#functions/auth.config.ts"
 import authSchema from "#functions/components/better-auth/schema.ts"
 
-export const authComponent = createClient<DataModel, typeof authSchema>(components.betterAuth, {
+const authFunctions: AuthFunctions = internal.auth
+
+export const authComponent = createClient<DataModel, typeof authSchema>(components.auth, {
+  authFunctions,
   local: { schema: authSchema },
 })
 
-export const authOptions = (ctx: GenericCtx<DataModel>) =>
+export const createAuthOptions = (ctx: GenericCtx<DataModel>) =>
   ({
     advanced: {
       cookiePrefix: APP_ID,

--- a/packages/backend/src/functions/system/health.ts
+++ b/packages/backend/src/functions/system/health.ts
@@ -1,0 +1,5 @@
+import { internalQuery } from "#functions/shared/convex.ts"
+
+export const ping = internalQuery
+  .handler(async () => ({ ok: true, timestamp: Date.now() }))
+  .internal()


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the backend from `convex-helpers` to `fluent-convex`, modernizing the middleware-based architecture for query/mutation builders. The migration simplifies authentication patterns by replacing custom function wrappers with cleaner middleware composition.

**Key changes:**
- Replaced `customQuery`/`customMutation`/`customAction` from convex-helpers with fluent-convex's builder pattern
- Consolidated auth configuration into `createAuthOptions` function and moved to `#functions/shared/auth.ts`
- Added new `internalQuery`/`internalMutation`/`internalAction` builders for internal-only endpoints
- Migrated from `vv` (typed validators) to native `v` from convex/values
- Added CORS configuration to HTTP route registration

**Critical issues found:**
- `adapter.ts:6` - `createAuthOptions` passed without calling it, needs `ctx` parameter
- `users.ts:12` - `.public()` on `privateQuery` bypasses admin authentication

**Pattern inconsistency:**
- Some public queries use `.public()` terminator (messages, documents, auth) while others don't (models/documents). The fluent-convex pattern may require `.public()` to explicitly mark visibility.

<h3>Confidence Score: 1/5</h3>

- Critical authentication bypass and type error will cause runtime failures
- Two critical bugs found: (1) admin endpoint exposed publicly in users.ts bypassing authentication, (2) function reference error in adapter.ts will cause type/runtime errors. These must be fixed before merge.
- packages/backend/src/functions/components/better-auth/adapter.ts and packages/backend/src/functions/private/users.ts require immediate fixes

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/backend/src/functions/shared/convex.ts | Successfully migrated from convex-helpers to fluent-convex with cleaner middleware-based auth patterns |
| packages/backend/src/functions/components/better-auth/adapter.ts | Critical: `createAuthOptions` function passed without calling it - will cause type error |
| packages/backend/src/functions/private/users.ts | Critical: `.public()` on `privateQuery` bypasses admin authentication middleware |
| packages/backend/src/functions/public/messages.ts | Migrated to fluent-convex pattern with `.public()` - may be redundant with `publicQuery` |
| packages/backend/src/functions/models/documents.ts | New file implementing fluent-convex middleware pattern for document operations |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[convex-helpers] -->|Replaced by| B[fluent-convex]
    
    B --> C[createBuilder]
    C --> D[Base Builders]
    
    D --> E[convex.query]
    D --> F[convex.mutation]
    D --> G[convex.action]
    
    H[Middleware] --> I[withLogger]
    H --> J[withAuthentication]
    H --> K[withAdmin]
    
    E --> L[publicQuery]
    E --> M[protectedQuery]
    E --> N[privateQuery]
    E --> O[internalQuery]
    
    I --> L
    I --> M
    I --> N
    I --> O
    
    J --> M
    K --> N
    
    L --> P[.handler.public]
    M --> Q[.handler]
    N --> R[.handler - ISSUE: .public bypasses auth]
    O --> S[.handler.internal]
    
    style R fill:#ff6b6b
    style P fill:#51cf66
    style S fill:#51cf66
```

<sub>Last reviewed commit: 19b77cb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->