### PR TITLE
chore: add improvement plans for CLI, packages, apps, and tooling

### DIFF
--- a/.plans/01-cli-correctness-fixes.md
+++ b/.plans/01-cli-correctness-fixes.md
@@ -1,0 +1,59 @@
+# Plan 01 — CLI correctness fixes
+
+Small, independent bug fixes in `cli/` (the `init-now` CLI). No feature work — that is plan 04/06. The CLI is an Effect-based app (`@effect/cli`), bundled with bunup, published to npm. It has its own `bun.lock` and tests (`cd cli && bun test`).
+
+## Bugs to fix
+
+### 1. Scaffold overwrite is broken
+
+`cli/src/index.ts:64-73`: the root command prompts "directory exists, overwrite?" but never clears the directory nor passes `force: true` to giget's `downloadTemplate` (`cli/src/index.ts:76`). giget throws when the target dir is non-empty, so answering "yes" produces a `DownloadFailed` error.
+
+Fix: on confirmed overwrite, pass `force: true` (or `forceClean: true` if full replacement is desired — check giget docs) to `downloadTemplate`.
+
+### 2. Wrong `--version` output
+
+`cli/src/index.ts:113` hardcodes `"2.0.0"` in `Command.run` while `cli/package.json` says `2.0.2`. Read the version from `cli/package.json` at build time (bunup define/macro) or import it, so there is a single source of truth. (Plan 09 formalizes this as a Bun macro following `../adamantite/src/lib/shared/version.macro.ts` — a plain JSON import is fine here if 09 hasn't landed.)
+
+### 3. `compareVersions` breaks on the actual tag format
+
+Release tags are `init@v1.1.0` (release-please config: `tag-separator: "@"`, `include-component-in-tag: true` in `release-please-config.json`). `compareVersions` (`cli/src/utils.ts:126-146`) only strips a leading `v`, so `"init@v1.1.0".split(".")` yields `[NaN, 1, 0]` — NaN comparisons silently return equal, and the major version is ignored.
+
+Fix: normalize tags by stripping the `<component>@v` prefix (regex like `/^.*@v?/`) before comparing. Also make non-numeric segments an explicit error or treat the version as unknown instead of silently comparing NaN.
+
+### 4. `.template-version.json` format corruption
+
+The file starts as `{".": "1.1.0"}` (it doubles as the release-please manifest). `updateTemplateVersion` (`cli/src/utils.ts:148-153`) writes the raw tag (`init@v1.1.0`) after an update, producing a format neither release-please nor `getVersion` (`utils.ts:83-101`) expects on the next run.
+
+Fix: always store the bare semver (`1.1.0`). Normalize when writing AND when reading (defensive, for projects already corrupted).
+
+### 5. `check` unreachable branch
+
+`cli/src/commands/check.ts:24-27`: `if (!latestRelease)` is dead — `getLatestRelease` fails with `VersionCheckFailed` (handled via `catchTag` at `check.ts:59`), it never succeeds with `null`. Delete the branch.
+
+### 6. Duplicated `updatePackageJson`
+
+`cli/src/commands/setup.ts:42-52` does regex string-replacement on package.json (fragile: depends on exact `"name": "init"` formatting, rewrites first `"version"` match). `cli/src/commands/rename.ts:11-21` does it properly via JSON parse/serialize. Extract the JSON-based implementation into `cli/src/utils.ts` and use it in both.
+
+### 7. Stale exclusion/cleanup lists
+
+- `cli/src/utils.ts:175`: `EXCLUDED_DIRS` contains `"scripts/template"`, which no longer exists.
+- `cli/src/commands/setup.ts:101`: `cleanupInternalFiles` removes a root `__tests__` dir that no longer exists, and misses newer internal files (`.github/workflows/opencode.yml`, `cli/.claude`, `.plans/`).
+
+Fix: refresh both lists against the current template tree. (Plan 04 replaces these with a manifest — keep this fix minimal.)
+
+### 8. Minor dead code
+
+- `cli/src/utils.ts:78`: `export type ReleaseInfo` — unused, delete or stop exporting.
+- `cli/src/commands/setup.ts:168`: `const packages = selectedPackages` pointless alias.
+
+## Acceptance criteria
+
+- `init-now <name>` into an existing non-empty dir with "overwrite: yes" succeeds.
+- `init-now --version` prints the version from `cli/package.json`.
+- `compareVersions("init@v2.0.0", "1.1.0")` reports an update available; add unit tests in `cli/src/__tests__/` covering tag formats: `1.1.0`, `v1.1.0`, `init@v1.1.0`.
+- After a simulated update, `.template-version.json` contains `{".": "<bare semver>"}`.
+- `cd cli && bun test` passes; `bun run check` at root passes.
+
+## Out of scope
+
+Manifest generation, setup/backend selection, update-command semantics (plans 04 and 06). npm publish automation (plan 08). Effect v4 migration, adamantite adoption, CLI CI (plan 09) — keep these fixes on the current Effect v3 APIs so they can land immediately.

--- a/.plans/02-package-consolidation.md
+++ b/.plans/02-package-consolidation.md
@@ -1,0 +1,70 @@
+# Plan 02 — Package consolidation & dead-code sweep
+
+Consolidate micro-packages and remove dead code from `packages/`. Decisions below are final (agreed with the maintainer) unless marked "confirm first".
+
+Anything removed that is still _useful as copy-once code_ must be recorded in `.plans/07-registry.md` under "Registry backlog" instead of being lost — append to that list as you delete.
+
+## 1. Merge `@init/error` into `@init/core` as `@init/core/errors`
+
+`packages/error` (85 LOC, faultier-based tagged errors) disappears; `packages/core` (currently a placeholder with literal `unused()` exports) becomes the home for domain primitives.
+
+Steps:
+
+1. Delete placeholder content: `packages/core/src/index.ts` `unused()`, `packages/core/src/features/` (`unusedFeature()`, `.gitkeep`), and the `"./features/**"` export in `packages/core/package.json`.
+2. Move `packages/error/src/*` → `packages/core/src/errors/` (keep the domain split: `auth.ts`, `email.ts`, `utils.ts`, barrel `index.ts`). Add `faultier` to core's dependencies.
+3. Core exports: `"."` and `"./errors"` only. Do NOT replicate error's `"./*"` wildcard — consumers used only the root barrel.
+4. Update all consumers from `@init/error` → `@init/core/errors`:
+   - `apps/app/src/shared/server/middleware.ts`
+   - `apps/app/src/shared/server/serialization.ts`
+   - `packages/email/src/client.ts`
+   - `packages/backend/src/functions/models/documents.ts`
+   - `packages/backend/src/functions/shared/convex.ts`
+   - `packages/utils/src/assert.ts` — being deleted anyway (see §3)
+   - package.json deps in: `apps/api` (declared but unused in src — just remove the dep), `apps/app`, `packages/email`, `packages/utils`, `packages/backend`
+5. Delete `packages/error/`. Update `cli/src/workspaces.ts` (remove the `error` entry, add/keep `core`) and the knip config if it references error.
+
+## 2. Delete `@init/storage`, decouple storage records from the implementation
+
+`packages/storage` (51 LOC) has no runtime consumers. Only `packages/db/src/schema.ts:1-2` imports it — types only (`StorageBucket` from `buckets.ts`, `MimeType` from `helpers.ts`). Future storage support will use `files-sdk` directly from the API composition root and its client/backend integrations; it will not recreate an `@init/storage` wrapper.
+
+Steps:
+
+1. Remove the `StorageBucket` and `MimeType` imports and their `.$type<...>()` annotations from `packages/db/src/schema.ts`; keep `bucket` and `mimeType` as plain text columns. Do not move these implementation types into db or add `mime` there. Bucket names are deployment configuration, and MIME values can include parameters such as `text/plain; charset=utf-8` that the old static type excludes.
+2. Replace the `storage_provider` PostgreSQL enum with a text `provider` column while preserving the `"s3"` default. A database migration is required. Do not encode `files-sdk`'s provider catalog as a database enum: generated projects should be able to add an adapter without altering a template-owned TypeScript type, while each project may add its own constraint if desired.
+3. Remove `@init/storage` from `packages/db/package.json`. No replacement db dependency is needed.
+4. Delete the unused runtime helpers rather than preserving their implementation: `files-sdk` replaces the S3 factory and provides content-type facilities; the current silent key sanitizer is not a sufficient authorization or key-policy boundary. Plan 07's registry backlog contains the replacement `files-sdk` integration recipe, not a copy of these helpers.
+5. Delete `packages/storage/`. Remove the `s3` env preset from `packages/env/src/presets.ts` (its only purpose was this package); the future registry recipe adds only the selected provider's validated variables. Update `cli/src/workspaces.ts` and knip config.
+
+## 3. Dead-code sweep
+
+Delete, updating package.json deps/exports accordingly:
+
+- `packages/utils/src/assert.ts` and `packages/utils/src/codec.ts` — zero importers. Add both to registry backlog.
+- `unstorage` dependency in `packages/utils/package.json` — nothing imports it.
+- `packages/env/src/presets.ts`: delete `railway`, `openai`, `anthropic` presets (no corresponding package/consumer). KEEP `convex` (serves `packages/backend`), `posthog` (serves `packages/analytics`), `stripe` (payments), `resend` (email). Delete `s3` per §2.
+- `packages/observability`: delete `src/uptime.ts`, the `./uptime` export, and the `@openstatus/react` dependency.
+- `packages/auth`: delete `src/integrations/expo/{client,server}.ts` (pure re-exports of `src/expo/*`; only `@init/auth/expo/client` is imported, by apps/mobile) and the corresponding export-map entries. Move `src/integrations/start.ts` (tanstack-start cookies, unused) to registry backlog and delete. Delete unused `createErrorHandler` in `src/client/index.ts`.
+- `packages/ui`: remove the `./hooks/*` export from package.json (`use-mobile.ts` is internal to sidebar — keep the file). Fix `src/components/theme.tsx` importing from its own package name `@init/ui/...` — use `#` subpath imports like the rest of the package.
+- `packages/db/src/helpers.ts`: delete unused `increment`/`decrement`; add to registry backlog.
+- `packages/analytics`: KEEP the package (selectable unit), but dedupe the copy-pasted `useIdentifyUser` between `src/product/react.ts` and `src/product/expo.ts` (extract shared logic).
+- `packages/email/src/client.ts`: dedupe the verbatim `MOCK_RESEND` preview logic between `sendEmail` and `batchEmails`.
+- `packages/payments/src/helpers.ts`: delete `createAgentToolkit` (Stripe AI Agent Toolkit) and its deps; add to registry backlog (confirmed by maintainer). Keep the rest of payments.
+- `packages/ai`: KEEP as-is (selectable unit, maintainer decision).
+
+## 3b. Root-level dead infrastructure
+
+- **Delete `scripts/`** (decided — leftover from previous tooling work): `scripts/index.ts` is an empty yargs shell, `scripts/helpers.ts` a 5-line identity helper. Remove the `"scripts"` entry from root `package.json` scripts, the `scripts/**` entries in `knip.config.ts`, and mentions in `AGENTS.md`/`docs/project-structure.md` (the "scripts" folder description).
+- **Prune orphaned root devDependencies**: with `scripts/` gone and the CLI standalone, verify and remove unused root devDeps — `yargs`, `@types/yargs`, and check whether `effect`, `@effect/cli`, `@effect/platform`, `@effect/platform-bun`, `@octokit/rest` are used by anything at root (turbo generators, etc.); remove those that aren't (`bun run analyze` should confirm).
+- `packages/kv`: refactor the `class` wrapper to a factory function, per the repo's own "avoid classes" style rule (behavior unchanged).
+
+## 4. Keep `cli/src/workspaces.ts` consistent
+
+Every package added/removed above must be reflected in `cli/src/workspaces.ts` and its test (`cli/src/__tests__/workspaces.test.ts`) so `init-now setup` doesn't offer deleted packages. (Plan 04 replaces this file with a generated manifest; here, just keep it truthful.)
+
+## Acceptance criteria
+
+- `packages/error` and `packages/storage` no longer exist; `rg "@init/error|@init/storage" --glob '!node_modules'` returns nothing.
+- Db storage records use plain text for provider, bucket, and MIME type and have no dependency on `mime`, `files-sdk`, or provider-specific types.
+- `@init/core` has real content (`errors/`) and no `unused()` placeholders.
+- `bun run check`, `bun run analyze` (knip should report fewer issues, none new), `bun run check:monorepo`, `bun test`, and `cd cli && bun test` all pass.
+- Registry backlog section in `.plans/07-registry.md` lists every useful deletion.

--- a/.plans/03-app-hygiene.md
+++ b/.plans/03-app-hygiene.md
@@ -1,0 +1,77 @@
+# Plan 03 — App hygiene
+
+Fix half-wired integrations, placeholders, and gaps across `apps/`. Guiding principle: **no external services required** — everything here must work with local dev alone (docker compose, mock modes). Sentry/PostHog/Resend remain opt-in; we add the local seams they'd plug into.
+
+## 1. Error boundaries (no external services needed)
+
+- `apps/app/src/router.tsx`: add a `defaultErrorComponent` (styled with `@init/ui`, offers "try again" via router invalidate). Currently only `defaultNotFoundComponent` is set — uncaught route errors white-screen.
+- `apps/desktop/src/router` setup: same treatment.
+- `apps/mobile`: export `ErrorBoundary` from the root layout (`src/app/_layout.tsx`) per expo-router convention, with a minimal fallback screen using `#shared/components/ui`.
+
+These are plain React fallbacks. Log through `@init/observability` logger (already local-safe); do not wire Sentry.
+
+## 2. Fix the forgot-password lie
+
+`apps/app/src/features/auth/server/functions.ts:25-37` mocks `forgotPassword` with a `setTimeout`, and the UI (`apps/app/src/features/auth/components/forgot-password-form.tsx`) shows a success toast for an email never sent — while `@init/email` sits unused.
+
+Fix (agreed direction):
+
+1. Wire better-auth's `sendResetPassword` in `apps/api/src/shared/auth.ts` using `@init/email` (`sendEmail`). `@init/email` already has a `MOCK_RESEND` mode that logs/previews instead of sending — local dev needs no Resend key.
+2. Replace the mocked server function so the flow goes through better-auth's actual reset endpoint.
+3. Local verification is `MOCK_RESEND` logging/preview — decided: no mailpit/SMTP catcher (`@init/email` is Resend HTTP API; an SMTP path just for dev isn't worth it).
+4. Remove the stray copied comment "// Add your global server functions here" from the feature's functions file.
+
+## 3. Dead/broken env modules
+
+- `apps/web/src/shared/env.ts`: never imported and contains a literal `TEST_VAR` placeholder. Either wire it into `astro.config.ts` via `@tooling/env`'s `ensureEnv` (like other apps) with real vars, or delete the file until web has env needs. Prefer wiring it — env validation is a claimed template feature.
+- `apps/extension/src/shared/env.ts`: never imported, validates `VITE_API_URL` while sibling apps use `PUBLIC_API_URL`, and `runtimeEnv: process.env` cannot see Vite client env at runtime. Fix all three: consistent `PUBLIC_` prefix (WXT supports `import.meta.env`), correct runtimeEnv source, and import it from `wxt.config.ts`/entrypoints.
+
+## 4. Placeholder & dead-weight cleanup
+
+- `apps/api/src/functions/example.ts`: entirely commented-out, exports `null`. Delete (violates repo comment policy). `apps/api/src/routes/workflows.ts` already defines its own demo function.
+- `apps/api`: collapse the three overlapping demos (`/v1/hello`, `hello` tRPC procedure, `/ping`) to one exemplar of each transport (one REST route with OpenAPI schema, one tRPC procedure). Keep `/health`.
+- `apps/app/src/routes/api/test.ts`: delete.
+- `<TanStackDevtools>` rendered unconditionally in `apps/app/src/routes/__root.tsx` and `apps/desktop/src/routes/__root.tsx`: gate on `import.meta.env.DEV`.
+- `apps/extension`: remove the three unused `@webext-core/*` deps (`proxy-service`, `job-scheduler`, `isolated-element`) from package.json; delete the empty `src/entrypoints/content.ts` (matches `*://*.google.com/*` and does nothing) or give it a one-line real example.
+- `apps/desktop/src/shared/assets/react.svg`, `apps/extension/src/shared/assets/react.svg`: delete leftover starter assets.
+- `apps/mobile`: delete unused `src/shared/components/ui/alert.tsx`, `ui/toggle.tsx`, `external-link.tsx`, and stock Expo images (`react-logo*.png`, `partial-react-logo.png`).
+- `apps/mobile/android/sentry.properties` (and iOS equivalent): remove hardcoded `defaults.org=metaideas` / `init-mobile` values (genericize/placeholder them). Decided: `ios/`/`android/` **stay committed** — do not gitignore them; just fix the leaked template-author values.
+- `apps/docs`: minimum viable de-starterization — fix the social link in `astro.config.ts` (points at `https://github.com/withastro/starlight`), remove the dead Paraglide codegen (`@inlang/paraglide-js` dep + `codegen` script + `src/shared/internationalization/` output — Starlight uses its own i18n), remove the unused React integration (`@astrojs/react`), replace stock example content with 1-2 short pages about the scaffolded project. Keep the app.
+- `apps/web`: replace the meta-refresh redirect in `src/pages/index.astro` with a proper redirect (Astro `redirects` config or middleware); add root `404.astro`; add `@astrojs/sitemap` + RSS for the blog (standard marketing-site table stakes, no external services).
+- Paraglide i18n: compiled output is generated into all 7 apps but consumed only by `app` and `web`. Remove the codegen wiring from `desktop`, `extension`, `mobile`, `docs` (keep the `@tooling/internationalization` package; apps can re-add codegen when they need i18n).
+- `apps/api` context wiring: the global tRPC/route context hard-sets `session: null` while `requireSession` resolves per-request — confusing double wiring. Make session resolution live in one place (the middleware) and remove the misleading context default/comment.
+- `apps/mobile`: **delete the unreachable better-auth client** (`src/shared/auth.ts` — full client with admin/org plugins, imported by nothing) and drop `@init/auth` from mobile's deps. Decided: mobile ships without an auth client by default; it returns as two registry items (plan 07): `mobile-auth-client-api` (points at `apps/api`'s better-auth handler) and `mobile-auth-client-convex` (uses `@convex-dev/better-auth`'s client plugin + Convex site URL). Keep `@init/auth`'s expo subpaths — they serve the registry items and package selection.
+
+## 4b. Desktop: local-first direction (decided)
+
+`apps/desktop` stays and gets **smart, local-first investment** — desktop apps often do local filesystem work with no API at all, so outbound connections are unnecessary by default:
+
+- Replace the `greet` demo (`src-tauri` command + `features/demo`) with a small, genuinely useful **local filesystem example**: e.g., a feature that picks a directory/file via the Tauri dialog plugin, reads/writes it through a Rust command or the fs plugin, and shows the Tauri `invoke` + TanStack Query `mutationOptions` pattern on something real.
+- Remove the API-oriented wiring that exists "by default": `PUBLIC_API_URL` in `src/shared/env.ts` and the unused URL builder in `shared/utils.ts`. Connecting desktop to the API/auth becomes an opt-in registry item later (plan 07), not template default.
+- Keep: the Tauri/Vite config (`TAURI_*` handling), theme toggle, router shell, error boundary (§1).
+- No auth, no tRPC client, no i18n by default.
+
+## 5. Turbo/CI wiring
+
+- `apps/api/turbo.json`: delete phantom `build:types` and `deploy` tasks (no corresponding package.json scripts).
+- Add `turbo.json` with `build` `outputs` for `apps/web` and `apps/docs` (Astro `dist/`) so builds cache.
+- Root `turbo.json` build env: move API-only vars (`INNGEST_*`, `REDIS_URL`) out of the global build env into `apps/api`'s task config.
+- `apps/app/src/shared/env.ts` + `apps/app/turbo.json`: the frontend extends `db()` preset and lists `DATABASE_URL`/`RESEND_API_KEY` in build env, but app talks to the DB only via the API. Remove server-side presets/vars that belong to `api`.
+- `.github/workflows`: add a `turbo build` job (build all apps) so PRs catch build breakage — currently only lint/format/test run, and there are ~2 test files.
+- `infra/local/docker-compose.yml`: add `healthcheck` blocks to redis/postgres/minio/inngest, and bootstrap the MinIO buckets declaratively (an `mc`-based init container creating the buckets from `packages/db`'s `StorageBucket` constants) — today the bucket only exists because it was created by hand in the gitignored `.data` dir. This bootstrap also serves plan 07's files-sdk contract suite, which runs live against local MinIO.
+
+## 6. Seed real tests
+
+Make `tests.yml` meaningful with a few high-value tests (bun:test, `__tests__` folders per repo convention):
+
+- `apps/api`: middleware test (auth-required route rejects anonymous, health returns ok) using Hono's test client. The empty `apps/api/src/shared/__tests__/` dir is waiting for this.
+- `apps/app`: one server-function or serialization test (`src/shared/server/serialization.ts` is pure logic).
+- Keep scope small — the goal is patterns for template users to copy, not coverage.
+
+## Acceptance criteria
+
+- `bun run check`, `bun run analyze`, `bun test`, `turbo build` all pass locally.
+- No route in `app` can white-screen without a styled fallback.
+- Forgot-password flow completes against local stack with no external keys (email visible via MOCK_RESEND logging/preview).
+- `rg "TEST_VAR|@webext-core" --glob '!node_modules'` returns nothing.
+- CI includes a build job.

--- a/.plans/04-cli-manifest-and-setup.md
+++ b/.plans/04-cli-manifest-and-setup.md
@@ -1,0 +1,70 @@
+# Plan 04 — CLI manifest & setup rework
+
+Replace the hardcoded, drifted workspace list in `cli/src/workspaces.ts` with a **generated manifest**, add transitive dependency resolution to `init-now setup`, introduce an explicit backend choice, and support non-interactive use.
+
+Prereqs: plan 01 (correctness fixes), plan 02 (final package set), and plan 09 (Effect v4 + adamantite + service structure) should land first — write this feature work against the v4 APIs and the `lib/services` structure plan 09 introduces.
+
+## Problem summary
+
+- `cli/src/workspaces.ts` is a handwritten `as const` list of apps/packages with dependency arrays. It has already drifted from reality (~12 packages list wrong `@init/*` deps), and the package-level `dependencies` arrays are never read by any code.
+- `setup` (`cli/src/commands/setup.ts:137-171`) resolves app→package dependencies only one level deep. Concrete failure: selecting the `api` app keeps `db` but drops packages `db` itself depends on → dangling `workspace:*` deps → broken install.
+- The CLI test (`cli/src/__tests__/workspaces.test.ts`) validates apps only — exactly not where the drift is.
+- Everything is prompt-driven; unusable in CI.
+
+## 1. Generated manifest
+
+Create a generator (suggested: `cli/scripts/generate-manifest.ts`, runnable via `bun run --cwd cli generate:manifest`) that walks the template's `apps/*/package.json`, `packages/*/package.json`, `tooling/*/package.json` and emits `manifest.json` at the repo root containing, per workspace:
+
+- `name` (npm name), `dir` (e.g. `packages/db`), `type` (`app` | `package` | `tooling`)
+- `description` (from package.json `description` — add descriptions to workspace package.jsons where missing, migrating the prose currently in `workspaces.ts`)
+- `dependencies`: `@init/*` / `@tooling/*` workspace deps (runtime + dev, flagged separately)
+- template metadata that today lives in hardcoded CLI lists: files/dirs that are template-internal (the `cleanupInternalFiles` list from `setup.ts:95-110`, `EXCLUDED_DIRS` from `utils.ts:163-180`) — a single `internalPaths` array in the manifest so setup/update share one source of truth (update uses it in plan 06).
+
+Wiring:
+
+- Commit `manifest.json`; add a CI check (in `adamantite.yml` or `tests.yml`) that regenerates and diffs it, failing when stale. This replaces the drift-prone test.
+- The CLI reads the manifest from the _downloaded/cloned template tree_ at runtime (giget result for create/setup, clone for update) — never from a bundled copy — so a published CLI always matches the template snapshot it's operating on.
+- Compatibility check (enabled by lockstep versioning, plan 08): after fetching a template snapshot, compare the CLI's own version against the snapshot's version and warn on **major** mismatch, suggesting `bunx init-now@latest`. Guards stale globally-installed CLIs against manifest/layout changes.
+- Delete `cli/src/workspaces.ts` and its test; add tests for the manifest reader + resolver instead.
+
+## 2. Setup: transitive resolution + backend choice
+
+Rework `cli/src/commands/setup.ts`:
+
+1. **Backend choice prompt** (before app selection): `Hono API (apps/api)` / `Convex (packages/backend)` / `none`. Consequences:
+   - Hono → keep `apps/api`; `packages/backend` deleted.
+   - Convex → keep `packages/backend`; `apps/api` deleted. Warn that `apps/app` currently requires `api` (hard-imports `api/client`) — deselect/flag `app` accordingly (encode this as a manifest field, e.g. `requires: ["api"]`).
+   - none → both deleted, same warning.
+2. **App multiselect** (excluding whichever backend workspaces the choice already settled).
+3. **Package preselection via transitive closure**: from selected apps' workspace deps, walk package→package deps to a fixpoint. Preselected-by-dependency packages should be shown but not deselectable (or deselecting them deselects dependents — pick the simpler UX: locked).
+4. **Optional extras multiselect** for packages nothing selected depends on (payments, ai, analytics, ...).
+5. **Post-prune validation**: after deleting unselected workspaces, scan remaining `package.json`s for `workspace:*` deps pointing at deleted workspaces and `rg`-style scan for `@init/<deleted>` imports. Fail loudly with the list, before `bun install`.
+6. Use the shared `internalPaths` from the manifest for cleanup instead of the hardcoded list.
+
+## 2b. Create-time version pinning
+
+The root create command (`cli/src/index.ts:76`) downloads `github:metaideas/init` — the tip of `main` — so scaffolded projects can contain unreleased content while `.template-version.json` records the last release cut on `main`. Fix:
+
+- Default the create command to the **latest release tag**: resolve it via the existing `getLatestRelease` logic and pass it as giget's ref (`github:metaideas/init#<tag>`). Fall back to `main` with a printed warning if the release lookup fails (offline/rate-limited).
+- Add `--ref <tag|branch>` to override (mirrors plan 06's update flag).
+- `setup` stamps `.template-version.json` with the version actually scaffolded (bare semver, per plan 01's format fix) instead of trusting the committed value.
+
+## 3. Non-interactive mode
+
+Add flags to `setup` (and the root create command where relevant): `--name <name>`, `--backend <api|convex|none>`, `--apps <a,b>`, `--packages <a,b>`, `--yes` (accept defaults, skip confirmations), `--no-install`, `--no-git`. Every prompt must have a flag equivalent. Validate flag values against the manifest and fail with the list of valid names.
+
+## 4. `add` command alignment
+
+`cli/src/commands/add.ts` currently offers workspaces from the hardcoded list and copies from `main`. Update it to:
+
+- Read available workspaces from the manifest (fetched from the template at the project's recorded version — see plan 06's ref-pinning; until then, `main` with a warning).
+- After copying: rewrite `@init/*` → project scope if the project was renamed (reuse `replaceProjectNameInProjectFiles`, scoped to the new workspace dir), add the workspace's own missing workspace-deps (transitive closure again — offer to add them), and run `bun install`.
+- Make `add app` and `add package` consistent (both should handle scope prefixing and `--destination` the same way).
+
+## Acceptance criteria
+
+- `manifest.json` generated, committed, CI-checked for staleness; `cli/src/workspaces.ts` deleted.
+- Scaffolding with only `api` selected produces a project where `bun install && bun run check` passes (transitive closure kept `db`'s deps).
+- `init-now setup --yes --backend api --apps app --name demo` completes with zero prompts.
+- Choosing Convex backend produces a project with `packages/backend`, no `apps/api`, and no dangling references.
+- `cd cli && bun test` covers: manifest parsing, transitive resolution (including the api→db dependency closure), backend-choice pruning, flag validation.

--- a/.plans/05-convex-backend-example.md
+++ b/.plans/05-convex-backend-example.md
@@ -1,0 +1,36 @@
+# Plan 05 — Convex backend example & conventions
+
+`packages/backend` (Convex + `@convex-dev/better-auth`) is an intentional **alternative** to `apps/api`: choose a self-managed Hono API, or a Convex backend (e.g., a mobile app that doesn't want to run a server). Decision: it **stays in `packages/`** — it is consumed like a library (React client + generated types) and deploys to Convex cloud, not our infra; this also matches Convex's own Turborepo conventions.
+
+The problem: today it has **zero consumers**, so the alternative is asserted but never demonstrated, and drift between the two auth setups goes unnoticed.
+
+## 1. Minimal consumption example in `apps/mobile`
+
+Mobile is the natural pairing (the stated use case). Add a small, clearly-optional example:
+
+- A screen (e.g. `src/app/convex-demo.tsx` or a `features/convex-demo` module per repo structure rules) that uses `@init/backend`'s React client (`packages/backend/src/client/index.ts`) — a `ConvexProvider` + one live query against an existing model (`packages/backend/src/functions/models/documents.ts`).
+- Env wiring: `EXPO_PUBLIC_CONVEX_URL` via the existing `convex` preset in `packages/env/src/presets.ts`, validated in `apps/mobile/src/shared/env.ts`.
+- Add `@init/backend` to `apps/mobile/package.json`.
+- Keep it deletable: the example must be self-contained (one feature folder + one route + one provider wrapper) so choosing the Hono backend in `init-now setup` (plan 04) can delete `packages/backend` and this example folder cleanly. Document the coupling in the manifest if plan 04 has landed (e.g. example ships only when backend=convex); otherwise leave a note in the feature's README.
+
+Constraint: **no external service required to pass CI** — `convex dev` needs an account, so the example must typecheck and build without a running deployment (guard the provider on env presence, render a "Convex not configured" state otherwise). Same pattern as Sentry: wired seam, opt-in service.
+
+## 2. Reduce duplication between the two backends
+
+Don't force-share code between alternatives (they must delete cleanly), but eliminate accidental drift:
+
+- Auth config: `packages/backend/src/functions/shared/auth.ts` vs `apps/api/src/shared/auth.ts` duplicate better-auth settings (session/user config). Extract genuinely shared, service-free constants (session TTLs, cookie names, plugin lists if identical) into `@init/auth` so both consume one source. Leave provider-specific wiring in place.
+- `LoggerCategory.CONVEX` in `@init/observability`: fine to keep (observability is cross-cutting), but verify the category is actually used by `packages/backend` logging; delete if not.
+
+## 3. Documentation & conventions
+
+- `AGENTS.md`: the Project Structure section says deployables live in `apps/`. Add a carve-out: _hosted-platform backends consumed as libraries (e.g., Convex) live in `packages/`_. This prevents relitigating the placement.
+- `docs/project-structure.md`: same clarification; also fix the stale claim that `scripts/` contains the template-sync script (sync lives in the `init-now` CLI).
+- Add a short `packages/backend/README.md` section (or extend the existing one): when to choose Convex vs `apps/api`, and that `apps/app` currently requires `apps/api`.
+
+## Acceptance criteria
+
+- `apps/mobile` imports `@init/backend` and renders the demo screen; app builds/typechecks with no Convex deployment configured.
+- Deleting `packages/backend` + the mobile example folder leaves a green `bun run check` (verify manually; plan 04 automates it).
+- No duplicated better-auth constants between the two backend stacks.
+- AGENTS.md and docs updated.

--- a/.plans/06-update-command-rework.md
+++ b/.plans/06-update-command-rework.md
@@ -1,0 +1,74 @@
+# Plan 06 — Update command rework
+
+Make `init-now update` a safe, reviewable sync instead of a blind overwrite. Prereqs: plan 01 (version/tag fixes), plan 04 (manifest with `internalPaths`), and plan 09 (Effect v4 migration — implement against the v4 APIs and service layers).
+
+## Current behavior and defects (`cli/src/commands/update.ts`)
+
+Flow today: compare `.template-version.json` against the latest GitHub release → require clean working tree → `git clone --depth 1` of **`main`** into `.template-sync-tmp` → `git ls-files` both trees → copy template files over local files → `git add .` → stamp the **release tag** into `.template-version.json` → user reviews staged diff.
+
+Defects:
+
+1. **"Skip locally modified files" is dead code** (`update.ts:46-50`): `ShellCommand.exitCode` succeeds with the code, which is discarded; and since the tree is required clean, `git diff HEAD -- <file>` can never differ anyway. Every committed customization is overwritten. Docs claim otherwise (`docs/template-commands.md:69`).
+2. **Version/content skew**: clones `main` but records the release tag.
+3. **Rename not idempotent**: copied files reintroduce `@init/*` into renamed projects; the rename is never re-applied.
+4. **Re-adds internal files** that `setup` deleted (`cli/`, `release-please-config.json`, `.github/workflows/release.yml`): they're "new" files not under `apps/*`/`packages/*`, so `filterNewFilesForExistingWorkspaces` (`update.ts:105-125`) lets them through.
+5. **Deletions never propagate.**
+6. Misc: handler regex-parses versions out of its own log message (`update.ts:248-255`); workspace listing shells out to `sh -c` (`update.ts:94-103`, non-portable); `git add .` stages everything.
+
+## Target design
+
+### 1. Sync from the tag it stamps
+
+Clone the release tag (`git clone --branch <tag> --depth 1`), not `main`. `.template-version.json` then always matches content (bare semver, per plan 01 fix). Add `--ref <tag|branch>` to override for testing against `main`.
+
+### 2. Base-aware three-way file classification
+
+We know the project's last-synced version (the recorded base). Clone/fetch **both** the base tag and the target tag (or one clone + `git worktree`/`git show base:<file>`). For each template file, compare three contents — base, target, local:
+
+| base vs target    | base vs local     | Action                                                                                                          |
+| ----------------- | ----------------- | --------------------------------------------------------------------------------------------------------------- |
+| unchanged         | anything          | skip (nothing to update)                                                                                        |
+| changed           | unchanged         | copy (clean update)                                                                                             |
+| changed           | changed           | **conflict** — prompt per file: keep local / take template / write `<file>.template` alongside for manual merge |
+| new in target     | absent locally    | add (respecting workspace filter)                                                                               |
+| deleted in target | unchanged locally | delete                                                                                                          |
+| deleted in target | changed locally   | prompt                                                                                                          |
+
+Important: compare against the _rename-normalized_ local content — apply the project-name → `@init` reverse substitution (inverse of `replaceProjectNameInProjectFiles`, `cli/src/utils.ts:242-268`) before diffing, so a rename alone doesn't mark every file "locally changed".
+
+### 3. Rename-aware application
+
+After copying files, re-run the `@init` → `@<project>` rewrite scoped to the files that were just written (project name from root `package.json`).
+
+### 4. Respect the manifest
+
+- Skip everything in the manifest's `internalPaths` (plan 04) — never re-add `cli/`, release config, internal workflows, `.plans/`, etc.
+- Keep the existing rule: new files under `apps/*`/`packages/*` only for workspaces present locally. Read workspace dirs with the `FileSystem` service, not `sh -c`.
+
+### 5. UX and safety
+
+- **CLI-only releases are no-ops** (consequence of lockstep versioning, plan 08): when the classification finds zero file changes between base and target, report "CLI-only release — nothing to sync", bump `.template-version.json` to the target, and exit cleanly. No staging, no conflict prompts.
+- `--dry-run`: print the full classification table (add/update/delete/conflict/skip) and exit.
+- Stage only files the command touched (explicit `git add <paths>`), plus `.template-version.json`.
+- Show the changelog range: fetch release notes for every release between base and target (Octokit `listReleases`), not just the latest.
+- Return structured data between steps (fix the regex re-parse).
+- On any failure, ensure temp dirs are cleaned (already done via `Effect.ensuring` — preserve).
+
+### 6. Docs
+
+Update `docs/template-commands.md` to describe the real behavior (the "only updates unmodified files" claim becomes true with §2). Note `check` shares the version logic — deduplicate `checkVersionUpdates` between `check.ts` and `update.ts` into a shared module.
+
+## Testing
+
+`cd cli && bun test` with fixture-based tests (two small fake git repos as base/target/local):
+
+- clean update, local-modification conflict, upstream deletion, renamed-project idempotency (run update twice — second run is a no-op), internal-path exclusion, `--dry-run` output.
+
+## Acceptance criteria
+
+- Updating a renamed project introduces zero `@init/` references.
+- A file customized-and-committed locally is never silently overwritten — it surfaces as a conflict.
+- Files deleted upstream are deleted (or prompted) locally.
+- `cli/`, `release-please-config.json`, `.github/workflows/release.yml` never reappear in user projects.
+- `.template-version.json` always equals the tag content that was synced.
+- `--dry-run` makes no writes.

--- a/.plans/07-registry.md
+++ b/.plans/07-registry.md
@@ -1,0 +1,96 @@
+# Plan 07 — Registry (init.now)
+
+Build a hosted code registry so the template ships a lean core while optional, copy-once code remains one command away. Prereqs: plans 02/03 (which populate the backlog below), 04 (CLI manifest/selection infrastructure), and 10 (the init.now marketing site, which hosts the registry: human-browsable index at `init.now/registry`, machine-readable JSON at `init.now/r/<item>.json` — the site reserves both routes as stable seams).
+
+## Model (decided)
+
+- **Packages stay packages**: units with their own third-party deps and lifecycle (payments, ai, analytics, kv, email, ...) remain selectable workspaces via `init-now setup` / `init-now add`.
+- **Registry items are copy-once leaves**: code the user owns after install — utilities, templates, components, integration snippets. No versioned dependency on the template afterward.
+- Registry items MAY target files inside existing `@init/*` packages (e.g., an analytics variant that drops files into `packages/analytics/src/` and appends an env preset).
+- **Format: the shadcn registry schema** (`registry.json` + per-item JSON). It is general-purpose (arbitrary files, target paths, npm deps, env vars, docs) and means `shadcn add <url>` works even before `init-now` grows registry support. `init-now` provides the selection UX and delegates installation.
+
+## 1. Registry content structure
+
+Create `registry/` in this repo (source of truth), built/deployed to `init.now/r/`:
+
+- `registry/registry.json` — index conforming to the shadcn registry schema.
+- `registry/<item>/` — item sources + item manifest (name, description, type, files with targets, npm `dependencies`, `registryDependencies`, env vars).
+- A build step that emits static JSON consumed by the `www/` site build (plan 10) and served at `https://init.now/r/<item>.json`. Add `registry` to knip/adamantite scopes so items stay lint-clean.
+- Fill in the `/registry` page on the site (plan 10 ships it as a placeholder): a simple browsable index rendered from `registry.json` with per-item install commands.
+
+Item targets must use template-relative paths (e.g. `packages/utils/src/codec.ts`), and contents use `@init/*` imports — the installer rewrites scope for renamed projects (§4).
+
+## 2. Registry backlog (initial items)
+
+Populated by deletions from plans 02/03 — agents executing those plans append here:
+
+- `codec` — SuperJSON codec util (was `packages/utils/src/codec.ts`)
+- `assert` — assertion helpers + `AssertError`/`UtilityError` types (was `packages/utils/src/assert.ts`, `packages/error/src/utils.ts`)
+- `db-counter-helpers` — Drizzle `increment`/`decrement` (was `packages/db/src/helpers.ts`)
+- `auth-tanstack-start-cookies` — (was `packages/auth/src/integrations/start.ts`)
+- `stripe-agent-toolkit` — (was `packages/payments/src/helpers.ts` `createAgentToolkit`)
+- `files-sdk` — complete storage integration recipe replacing `packages/storage/`: configured server instance, selected provider adapter, Hono backend route, browser/mobile client entry, authorization policy, validated env vars, conservative plugins, and asset-lifecycle hooks. It uses `files-sdk` directly and does not recreate an `@init/storage` package. See `docs/research/files-sdk.md` and §3 below.
+- `email-organization-invitation` — email template (from `packages/email/src/templates/`), plus future email templates generally
+- `mobile-auth-client-api` — the better-auth expo client removed from `apps/mobile` in plan 03 (`src/shared/auth.ts`), wired against `apps/api`'s better-auth handler, plus a minimal sign-in screen + session gate
+- `mobile-auth-client-convex` — same client wired for the Convex backend: `@convex-dev/better-auth` client plugin + Convex site URL as `baseURL`
+- `desktop-api-client` — opt-in wiring connecting `apps/desktop` to `apps/api` (env var, URL builder, fetch/tRPC client) — removed as a default in plan 03's local-first direction
+- env presets removed in plan 02: `railway`, `openai`, `anthropic`, `s3`
+- ~~`@init/ui` unused components~~ — **decided: NOT registry items.** All 57 components stay in the template: they are customized to fit the project (base-ui port, project theming), and the user model is "import what you need, delete the rest." Do not move them here.
+
+## 3. `files-sdk` recipe requirements
+
+Treat this as an application integration, not a thin S3-helper port:
+
+1. Install an exact-pinned `files-sdk` version initially and only the chosen adapter's optional peer dependencies. Default to `files-sdk/bun-s3` for the lightweight Bun template; document `files-sdk/s3` as the richer S3 option for provider metadata, cache control, delimiter listing, server-side copy, durable multipart uploads, and stronger signed-upload policies. Do not use runtime provider loading unless a generated project genuinely selects providers at runtime.
+2. Put the provider adapter, `Files` instance, bucket configuration, and plugin composition in `apps/api/src/shared/files.ts`. Mount the `files-sdk/hono` backend integration in `apps/api/src/routes/files.ts`. There is no shared storage workspace or wrapper API.
+3. Keep server and client imports separate so provider credentials and native SDKs cannot enter frontend bundles. Frontends use `files-sdk/client` or the relevant framework integration directly; server code uses provider subpaths.
+4. Make the backend deny-by-default. Integrate Init authentication, authorize operations plus bucket/key prefixes, validate file type and size before issuing upload authorization, and require a validated `FILES_API_SECRET`. Never rely on the SDK gateway's random per-process fallback, which is unsuitable across multiple instances.
+5. Start with a conservative plugin policy: content-type handling, validation, and signed-URL policy. Make audit/tracing integrate with Init observability when installed. Keep compression, encryption, deduplication, versioning, usage accounting, soft deletion, failover, and tiering opt-in because they change semantics, persistence, or cost.
+6. Keep `packages/db`'s `assets` table as the application source of truth for ownership, organization, lifecycle status, expiry, and application metadata. Provider object metadata is not authoritative. Signed direct uploads transfer bytes outside `Files.upload()`, so upload plugins alone cannot enforce or observe completion: the route must constrain authorization, verify the resulting object, and only then mark the asset available.
+7. Add a provider contract suite covering upload/download/head/exists/delete/list, content-type behavior, missing objects, pagination, signed download/upload constraints, large-object streaming, cancellation/timeouts, and normalized errors. Run a live suite against the selected provider; upstream primarily mock-tests adapters and currently has live coverage only for S3 and filesystem.
+8. Document capability differences instead of promising false portability. In particular, `bun-s3` lacks custom metadata, cache control, delimiter results, and server-side copy; its copy passes bytes through the process and resumable uploads buffer in-process. ACLs, signed URL expiry, upload limits, listing, metadata, and copy/move semantics vary across adapters. Use `files.capabilities` where available and keep provider-specific access behind the API composition root.
+9. Do not mirror all upstream providers into a database enum. Store provider, bucket, and MIME type as text; a generated project can impose its own allowlist if needed.
+
+The item may offer provider variants (for example `files-sdk-bun-s3`, `files-sdk-s3`, and `files-sdk-r2`) if the registry format cannot express a provider choice cleanly. Each variant must install only its own dependencies and env schema.
+
+### Cross-plan coordination
+
+- **The contract suite (item 7) runs against local MinIO — zero external services.** `infra/local/docker-compose.yml` already runs MinIO, and both `bun-s3` and `files-sdk/s3` accept custom endpoints. Point the live suite at the local MinIO endpoint; the bucket bootstrap added in plan 03 (§5, `mc` init container) provisions the buckets it needs. Cloud-provider live runs remain optional/manual, matching upstream's own policy.
+- **The recipe requires `apps/api` — declare it in the item manifest.** Projects that chose the Convex backend (plan 04 backend choice) cannot install it; use the same `requires: ["api"]` concept plan 04 introduces for workspaces so the CLI filters/explains instead of failing at install. A `files-sdk-convex` variant (the adapter exists) is a separate future item — the mount point differs too much to parameterize.
+- **Bucket constants have one owner: `packages/db`.** Plan 02 inlines `StorageBucket` into db; the recipe's `files.ts` composition and any prefix/bucket config must import those constants rather than define their own, so the `assets` table column types and the `Files` configuration cannot drift.
+- **This item settles the versioning open question (for itself):** the item manifest records the exact `files-sdk` version it was validated against (e.g. a `validatedAgainst` field surfaced in the item description), and bumping that pin requires re-running the contract suite before publishing the updated item. Given upstream's release velocity (16 releases in 11 weeks, breaking major within 6 weeks of 1.0), do not float the version.
+- **Env flows through the registry env mechanism (§4 step 3):** `FILES_API_SECRET` and the chosen adapter's provider vars ship as an env-preset addition applied on install, so `init-now add files-sdk-bun-s3` leaves env validation complete instead of printing a manual TODO.
+
+## 4. CLI integration
+
+Add `init-now add` support for registry items (extend plan 04's reworked `add`):
+
+1. Fetch `https://init.now/r/registry.json`, present a multiselect (grouped by item type/category) — this is the selection UX the maintainer wants owned by `init-now`.
+2. Install via one of (decide during implementation, prefer least code):
+   - Shell out to `bunx shadcn add <item-url>` and post-process, or
+   - A thin internal installer: download item JSON, write files to targets, `bun add` npm deps, honoring `registryDependencies`.
+3. Post-install steps `init-now` owns regardless of installer:
+   - Rewrite `@init/*` → project scope in installed files (reuse `replaceProjectNameInProjectFiles`, scoped to installed paths).
+   - If an item declares env vars, print (or append) the additions needed in `.env.local` / env presets.
+   - Verify target workspaces exist (an item targeting `packages/analytics` when the user never installed analytics → clear error naming the missing package and how to add it).
+4. `init-now add` UX: `init-now add app|package` (workspaces, plan 04) and `init-now add item <name...>` / bare `init-now add` interactive picker spanning both.
+
+## 5. Registry health
+
+- CI job: validate every item's JSON against the shadcn schema, and typecheck item sources (a throwaway tsconfig including `registry/**` with template path aliases).
+- A smoke test in `cli`: scaffold a temp project (or fixture), install one item (e.g. `codec`), assert file lands with rewritten scope and project typechecks.
+- Install the default `files-sdk` recipe into an API scaffold, assert it adds no `@init/storage` workspace or import, and verify server-only provider modules are absent from the client build.
+
+## Acceptance criteria
+
+- `registry.json` + at least the backlog items above are published and installable via `bunx shadcn add <url>` into a scaffolded project.
+- `init-now add` lists registry items and installs them with scope rewriting; works non-interactively (`init-now add item codec --yes`).
+- Installing `codec` into a renamed project yields imports under the project scope, and `bun run check` passes.
+- Installing a `files-sdk` provider variant produces a typechecking authenticated Hono route and client integration with only that provider's dependencies and validated env variables.
+- Template contains no copies of backlog item code (registry is the single home).
+
+## Decisions (settled with maintainer)
+
+- **`validatedAgainst` is the standard for every registry item that installs pinned third-party deps** (not just files-sdk): the item manifest records the exact validated dependency version; bumping it requires re-validating the item before publishing.
+- `@init/ui` components stay in the template in full (see backlog note above).
+- Whether `@init/ui`'s unused components move to the registry (bundle-size win vs. friction).

--- a/.plans/08-cli-release-automation.md
+++ b/.plans/08-cli-release-automation.md
@@ -1,0 +1,45 @@
+# Plan 08 — CLI release automation
+
+Automate versioning and npm publishing for the `init-now` CLI (`cli/`), ending version drift. Land after plan 01 (hardcoded banner version fix) and plan 09 (CLI CI workflow — the publish gate should require those jobs instead of duplicating test/build steps).
+
+## Current state
+
+- `cli/` is excluded from root Bun workspaces (`package.json` workspaces list only `apps/*`, `packages/*`, `tooling/*`) and has its own `bun.lock`.
+- Publishing is manual. Three conflicting versions exist right now: `cli/package.json` = `2.0.2`, root devDependency pin `init-now@2.0.1`, hardcoded banner `"2.0.0"` in `cli/src/index.ts:113`.
+- `release-please-config.json` covers only the root template package (`init`, manifest `.template-version.json`). `.github/workflows/release.yml` runs release-please for the template only — no npm publish step anywhere.
+
+## Tasks
+
+### 1. Add the CLI to release-please — **lockstep versioning (decided)**
+
+The template (`init`) and the CLI (`init-now`) share **one version number, always**. A significant template change bumps the CLI; a CLI change bumps the template. Rationale: one mental model ("init-now X.Y works with template X.Y"), one version to communicate on init.now. The accepted tradeoff — CLI-only releases produce template releases with no file changes — is mitigated in the `update` command (plan 06): when a sync classifies zero file changes, it reports "CLI-only release, nothing to sync" and just bumps `.template-version.json`.
+
+- Add a second package entry to `release-please-config.json`: path `cli`, component `init-now`, `release-type: node`, its own changelog (`cli/CHANGELOG.md`), and use release-please's **`linked-versions` plugin** to group `init` + `init-now` (and later `create-init-now`, plan 11) into one version. Keep per-component tags (`init@vX.Y.Z`, `init-now@vX.Y.Z`) — same version, distinct tags.
+- Adoption wrinkle: versions have already diverged (template `1.1.0`, CLI `2.0.2`). npm can't go backward, so the first linked release unifies both at the next version above the highest (e.g. `2.1.0`). One-way door — note it in the release PR.
+- Lockstep doubles as the compatibility check: the CLI compares its own (macro-inlined) version against the fetched template's version and warns on **major** mismatch ("run `bunx init-now@latest`") — protects stale globally-installed CLIs. No separate schema-version field needed.
+- Add `"cli"` to the manifest. Note: the manifest is `.template-version.json`, which the CLI also uses as the project marker and version record (`cli/src/utils.ts:83-101` reads key `"."`). Verify adding a `"cli"` key doesn't confuse `getVersion` (it reads `"."` specifically — should be fine; add a CLI unit test to lock that in). Also verify `setup`'s cleanup doesn't strip the `"cli"` key in scaffolded projects — scaffolded projects don't contain `cli/`, so release-please never runs there; leaving the extra key is harmless, but stripping it during `setup` is cleaner. Pick one and test it.
+
+### 2. npm publish workflow
+
+Extend `.github/workflows/release.yml` (release-please outputs per-path release flags):
+
+- When a `cli` release is created: `cd cli && bun install && bun run build && npm publish --provenance --access public` (bunup build per `cli/bunup.config.ts`; bin shim `cli/bin/init-now` imports `dist/`). Requires `NPM_TOKEN` secret (or npm trusted publishing/OIDC — prefer OIDC if configured).
+- Run `cd cli && bun test` as a gate before publish.
+- Confirm `cli/package.json` `files` includes `dist/` and `bin/` and nothing else leaks (no `dist/` currently gitignored issues, no `.claude/`).
+
+### 3. Single version source
+
+- Banner version read from `cli/package.json` (plan 01 item 2) — verify done.
+- Root `devDependencies["init-now"]`: bump to the current release. Optional: a small post-release automation (renovate rule or a step in the release workflow that opens a PR bumping the root pin). At minimum, document the manual step in `cli/README.md`.
+
+### 4. Conventional-commit scoping
+
+Ensure release-please attributes commits correctly: commits touching `cli/**` drive `init-now` releases (release-please does this by path automatically). Document in `cli/README.md`: CLI changes use normal conventional commits; no manual version bumps ever.
+
+## Acceptance criteria
+
+- Merging a `fix:` commit touching `cli/` to `main` produces a release-please PR bumping `init` and `init-now` to the **same version** (linked); merging it publishes `init-now` to npm with tag `init-now@vX.Y.Z` and cuts the template release `init@vX.Y.Z`.
+- Template-only releases also bump the CLI to the matching version and republish it.
+- After any release: `init-now --version` == npm version == template version in `.template-version.json`.
+- The CLI warns on major-version mismatch against a fetched template snapshot.
+- No hardcoded version strings remain: `rg '2\.0\.[0-9]' cli/src` returns nothing.

--- a/.plans/09-cli-effect-v4-and-tooling.md
+++ b/.plans/09-cli-effect-v4-and-tooling.md
@@ -1,0 +1,104 @@
+# Plan 09 — CLI: Effect v4 migration, adamantite tooling, and CI
+
+Modernize the `init-now` CLI (`cli/`): migrate to Effect v4 beta, adopt adamantite for lint/format/typecheck, add a dedicated GitHub Actions workflow, and guarantee all of it is stripped from scaffolded projects.
+
+**Reference implementation: `../adamantite`** (local checkout, `github.com/adelrodriguez/adamantite`). It is a standalone Effect v4 beta CLI with the exact target structure and tooling. When in doubt about v4 APIs or project layout, mirror what adamantite does.
+
+Prereq: plan 01 (correctness fixes) — land first so behavior fixes aren't tangled with the migration. This plan subsumes plan 01 item 2 (version string) via the macro pattern below. Plans 04 and 06 should be written against the migrated codebase, so this plan precedes them.
+
+## Context
+
+- CLI today: `effect@3.19.14`, `@effect/cli@0.73.0`, `@effect/platform@0.94.1`, `@effect/platform-bun@0.87.0`. Bundled with bunup, bin shim at `cli/bin/init-now`, own `bun.lock` (NOT part of root workspaces).
+- The CLI is currently excluded from all repo linting: root `oxlint.config.ts` ignores `cli/**` (tsgolint panics resolving the nested standalone tsconfig). So the CLI has no lint/format/typecheck enforcement at all today.
+- adamantite (the reference) uses `effect@4.0.0-beta.99` + `@effect/platform-node@4.0.0-beta.99`. `@effect/platform-bun` also has `4.0.0-beta.*` releases — prefer it since the CLI targets Bun (`bunup.config.ts` target) — but if v4-beta platform-bun lags or misbehaves, `@effect/platform-node` works under Bun (adamantite proves this).
+
+## 1. Migrate to Effect v4 beta
+
+Dependency changes in `cli/package.json`:
+
+- `effect` → `4.0.0-beta.x` (match adamantite's pinned beta or newer; pin exact).
+- **Remove** `@effect/cli` and `@effect/platform` — in v4 these live inside `effect` itself: `effect/unstable/cli` (`Command`, `Flag`, `Argument`, `Prompt`), `effect/FileSystem`, `effect/Terminal`, `effect/unstable/process/ChildProcess` (replaces `@effect/platform` `Command`/shell execution).
+- `@effect/platform-bun` → `4.0.0-beta.x` (`BunRuntime`/`BunServices`), or swap to `@effect/platform-node` (`NodeRuntime`/`NodeServices`) exactly as `../adamantite/src/index.ts` does.
+- Keep `giget` and `@octokit/rest` external per `cli/bunup.config.ts`; update the `external` list (`effect` stays external, dropped packages removed).
+
+API migration map (see adamantite for live examples of each):
+
+| v3 (current CLI)                                      | v4 (adamantite pattern)                                                                     | Reference                                       |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `import { Command, Prompt } from "@effect/cli"`       | `effect/unstable/cli/Command`, `.../Prompt`, `.../Flag`, `.../Argument` (namespace imports) | `../adamantite/src/commands/*.ts`               |
+| `@effect/platform` `Command` (shell)                  | `effect/unstable/process/ChildProcess` + `ChildProcessSpawner`                              | `../adamantite/src/lib/shared/process.ts`       |
+| `@effect/platform` `FileSystem`                       | `effect/FileSystem` (interface moved into core)                                             | `../adamantite/src/lib/shared/filesystem.ts`    |
+| `BunContext.layer` / `BunRuntime.runMain`             | `BunServices`/`NodeServices` layer + `Runtime`/`NodeRuntime` main                           | `../adamantite/src/index.ts`                    |
+| `Data.TaggedError` tagged errors (`cli/src/utils.ts`) | same concept; check `Data`/`Schema` error patterns                                          | `../adamantite/src/lib/shared/errors.ts`        |
+| Hardcoded version string in `Command.run`             | build-time macro: `getPackageVersion()` `with { type: "macro" }`                            | `../adamantite/src/lib/shared/version.macro.ts` |
+
+Migration is command-by-command: `index.ts` (root create), `commands/{setup,add,check,rename,update}.ts`, `utils.ts`. Behavior must not change — the existing tests in `cli/src/__tests__/` (plus any added by plan 01) are the regression net; extend them where coverage is thin before migrating a command.
+
+## 2. Restructure to match adamantite's layout
+
+Target structure (mirror `../adamantite/src`):
+
+```
+cli/src/
+  index.ts              # Command.make + withSubcommands + runtime bootstrap
+  commands/             # one file per subcommand (+ commands/__tests__/)
+  lib/
+    services/           # Context.Tag services (command runner, prompter, ...)
+    shared/             # errors.ts, filesystem.ts, process.ts, version.macro.ts
+  __tests__/
+```
+
+- Split the current `cli/src/utils.ts` grab-bag into `lib/shared/*` modules (errors, version/release lookup, file walking, project-name rewriting).
+- Adopt `#` subpath imports (`"imports": { "#*": "./src/*" }` in `cli/package.json`), matching both adamantite and this repo's own convention.
+- Wrap shell/prompt side effects in `Context.Tag` services (see `../adamantite/src/lib/services/command-runner.ts`, `prompter.ts`) so command logic is testable with stub layers — this directly benefits plans 04/06 test requirements.
+
+## 3. Adamantite support for the CLI
+
+The CLI stays outside root workspaces (own lockfile, published independently), so it gets its **own** adamantite setup, like the adamantite repo itself:
+
+- Add `adamantite` (+ `oxlint`, `oxfmt`, `knip` as its presets require — copy adamantite's own devDependencies approach) to `cli/package.json` devDependencies.
+- `cli/oxlint.config.ts` and `cli/oxfmt.config.ts` extending `adamantite/lint` + `adamantite/lint/node` and `adamantite/format` (see the repo root configs for consumer syntax; drop the react preset).
+- `cli/knip.config.ts` if adamantite's analyze needs it (root `knip.config.ts` already has a `cli` workspace entry — decide whether cli analysis moves fully local; prefer local so `cd cli && bun run analyze` is self-contained, and slim the root entry).
+- Scripts in `cli/package.json`: `check`, `format`, `fix`, `analyze` → `adamantite <cmd>`, plus existing `build`/`test`.
+- Root `oxlint.config.ts`: keep the `cli/**` ignore (the CLI now enforces itself), but update the comment to say the CLI runs its own adamantite setup.
+- Run `bun run fix` + `bun run format` inside `cli/` and resolve the initial wave of lint findings (expect real findings — this code has never been linted).
+
+## 4. GitHub Actions for the CLI
+
+Add `.github/workflows/cli.yml`, modeled on `../adamantite/.github/workflows/ci.yml`:
+
+- Trigger: `pull_request` and `push` to `main`, **filtered to `paths: [cli/**, .github/workflows/cli.yml]`** so template-only PRs don't pay the cost.
+- Matrix jobs, all with `workdir`/`defaults.run.working-directory: cli`: `check` (adamantite), `format --check`, `test` (`bun test`), `analyze`, `build` (bunup + verify `bin/init-now` runs `dist/index.js --version` successfully as a smoke test).
+- Setup: checkout, setup-bun, cache keyed on `cli/bun.lock`, `bun install --frozen-lockfile` in `cli/`.
+- Plan 08 (release automation) note: its publish gate should reuse/require this workflow's jobs rather than duplicating test/build steps.
+
+## 4b. Robustness fixes (ride along with the restructure)
+
+Address these while touching the affected modules — they're behavioral hardening, not features:
+
+- **Stop swallowing errors**: the codebase leans on `Effect.orElse(() => Effect.void)` / broad `catchAll` (`setup.ts:37,76,107`, `update.ts:84,88,211,218`, `utils.ts:101,153`), so partial failures still print "✅". With the v4 service structure, make failures explicit: either propagate, or downgrade to a printed warning — never silent success.
+- **Input validation**: `rename` accepts any string; apply the same name regex the create command uses (`index.ts:14`), npm-scope-safe. `setup`'s name prompt likewise.
+- **Tool preflight checks**: verify `git` (setup/update) and `turbo` (add) exist on PATH before starting, with actionable error messages.
+- **GitHub rate limits**: unauthenticated Octokit calls get 60 req/h/IP; on 403-rate-limit, print a clear message (optionally honor `GITHUB_TOKEN` env if present) instead of a generic `VersionCheckFailed`.
+
+## 5. Cleanup in scaffolded projects
+
+`init-now setup` already deletes `cli/` (`cleanupInternalFiles`, `cli/src/commands/setup.ts:95-110`). Extend the guarantee:
+
+- Add `.github/workflows/cli.yml` to the cleanup list (and `.github/workflows/release.yml` / `release-please-config.json` if not already covered — verify against the current list).
+- When plan 04 lands, these paths move into the manifest's `internalPaths` — ensure `cli/` and its workflow are in that list so `update` (plan 06) never re-adds them either.
+- Add a CLI test asserting the cleanup list covers: `cli/`, `.github/workflows/cli.yml`, `.github/workflows/release.yml`, `release-please-config.json`, `.plans/`. This is the regression net for "internal files leak into user projects".
+
+## Acceptance criteria
+
+- `cli/package.json` depends on `effect@4.0.0-beta.x` only (no `@effect/cli`, no `@effect/platform`); `cd cli && bun test` green; all commands behave identically (manual smoke: create → setup → check in a temp dir).
+- `cd cli && bun run check && bun run format --check && bun run analyze && bun run build` all pass.
+- `init-now --version` matches `cli/package.json` (macro-inlined, no hardcoded string).
+- `.github/workflows/cli.yml` runs and passes on a PR touching `cli/`; does not trigger on template-only changes.
+- A scaffolded project contains no `cli/` directory and no `.github/workflows/cli.yml` (covered by an automated test).
+
+## Risks / notes
+
+- Effect v4 is beta: pin exact versions, and expect `unstable/cli` API movement between betas — upgrading betas later is a `bump:deps` + fix cycle, acceptable for an internal tool.
+- Do the restructure (§2) and migration (§1) as one PR series but separate commits: move files first (no logic change), then migrate imports/APIs — keeps diffs reviewable.
+- If tsgolint/oxlint type-aware checks still panic on the standalone package, check how adamantite configures `typeAware`/`typeCheck` options in its own `oxlint.config.ts` and mirror it.

--- a/.plans/10-marketing-site.md
+++ b/.plans/10-marketing-site.md
@@ -1,0 +1,73 @@
+# Plan 10 — init.now marketing site
+
+Create the marketing page for init at **init.now** (domain already owned). It is deliberately barebones at v1 — modeled on the original `v1.run` (midday-ai/v1 template starter, see archived capture: https://web.archive.org/web/20260120054710/https://v1.run/). It also becomes the **host for the registry** (plan 07): human-browsable at `init.now/registry`, machine-readable JSON at `init.now/r/<item>.json`. Plan 07 now depends on this plan.
+
+## Reference: what v1.run was (entire page)
+
+- Logo + wordmark
+- One-line description ("An open-source starter kit based on Midday.")
+- A single copyable scaffold command (`bunx degit midday-ai/v1 v1`)
+- GitHub link, "Get updates" email capture, HN badge
+- A "Featuring" logo marquee (technologies in the stack)
+
+Nothing else. Match that scope discipline.
+
+## 1. Where it lives
+
+**In this repo, top-level `www/`** — following the `cli/` precedent: outside the root Bun workspaces, own lockfile, template-internal (never shipped to scaffolded projects).
+
+Rationale:
+
+- The registry build (plan 07's `registry/` → static JSON) deploys with the site in one pipeline; separate repos would split that.
+- `cli/` already establishes the "internal standalone dir" pattern, including cleanup in `init-now setup` and exclusion lists.
+- Not a workspace: the page must not depend on `@init/*` packages (it outlives template refactors, and a barebones page doesn't need them). If sharing ever matters, revisit.
+
+Do NOT confuse with `apps/web` — that is the _template's_ marketing-site starter for scaffolded projects. `www/` is marketing for init itself.
+
+## 2. v1 scope (barebones, single page)
+
+Stack: Astro (static output) — already used twice in this repo, zero-JS by default, trivially hosts static registry JSON later. Tailwind for styling. No React unless something actually needs interactivity.
+
+Content (copy decided by maintainer):
+
+- Logo/wordmark + headline **"Start once, ship everything"**, subheader **"Modern monorepo template for shipping TypeScript apps everywhere."** (same tagline as the README/GitHub — keep them in sync)
+- The scaffold command, copyable: `bunx init-now@latest my-app` with a copy button (the one place a splash of JS is warranted). Switches to `bun create init-now my-app` once plan 11 ships.
+- GitHub repo link
+- A compact "What's included" strip: the stack (Bun, Turborepo, Hono, TanStack Start, Expo, Drizzle, better-auth, Tailwind, ...) as text or small logos — the v1.run "Featuring" marquee equivalent
+- OG image + basic meta tags, favicon
+- Footer: license, GitHub
+
+Explicitly out of scope for v1 (decided): email capture ("Get updates"), docs content (the `apps/docs` starter is separate), blog, analytics, auth, any backend.
+
+## 3. Registry hosting seams (build now, fill in plan 07)
+
+- Reserve routes: `/registry` (human-browsable index page — placeholder or hidden until plan 07 ships) and `/r/*` (static JSON output directory).
+- The site build copies plan 07's built registry artifacts into the output (`www` build step consumes `registry/` build output when it exists; no-op until then).
+- Keep URLs stable from day one: `init.now/r/<item>.json` is the contract `init-now` and `shadcn add` will use.
+
+## 4. Deployment
+
+- **Vercel** (decided). Wire the `init.now` domain; connect the repo with the project root set to `www/`, so Vercel builds/deploys on `main` pushes and gives preview deployments on PRs touching `www/`.
+- `.github/workflows/www.yml`: path-filtered to `www/**` (and later `registry/**`) — build-only check on PRs (Vercel handles deploys). Mirror the setup-bun/cache steps from the CLI workflow (plan 09). If Vercel's own PR checks make this redundant, skip the workflow — don't duplicate CI.
+
+## 5. Template-internal cleanup
+
+`www/` and its workflow must never reach scaffolded projects:
+
+- Add `www/` and `.github/workflows/www.yml` to `cleanupInternalFiles` in `cli/src/commands/setup.ts` (and to the manifest `internalPaths` once plan 04 lands, so plan 06's `update` never re-adds them).
+- Add both to the cleanup-list test introduced by plan 09 §5.
+- Exclude `www/**` from root adamantite/knip scopes the same way `cli/**` is handled (own tooling inside `www/` if desired; a static Astro page may just need `bun run check` via its own tsconfig — keep it light).
+
+## Acceptance criteria
+
+- `init.now` serves the one-page site; Lighthouse-basics pass (meta, OG image, mobile layout); the scaffold command is copyable and correct.
+- `cd www && bun install && bun run build` produces a static output; CI workflow builds it on PRs touching `www/**` only.
+- `/r/` and `/registry` routes exist as stable seams (even if placeholder).
+- A scaffolded project contains no `www/` and no `www.yml` (covered by the cleanup-list test).
+
+## Decisions (settled with maintainer)
+
+- Tagline: "Start once, ship everything" / "Modern monorepo template for shipping TypeScript apps everywhere." (from README/GitHub)
+- Hosting: Vercel
+- Email capture: skipped for v1
+- Scaffold command: `bunx init-now@latest my-app` now; `bun create init-now` after plan 11

--- a/.plans/11-bun-create-support.md
+++ b/.plans/11-bun-create-support.md
@@ -1,0 +1,40 @@
+# Plan 11 — `bun create init-now` support
+
+Make `bun create init-now my-app` (and `npm create init-now` / `yarn create init-now` / `pnpm create init-now`) work as the canonical scaffold command. Decided: the marketing page (plan 10) ships with `bunx init-now@latest` and switches to `bun create init-now` once this lands.
+
+Prereqs: plan 08 (CLI release automation) — this plan extends its publish pipeline. Plan 09's restructure should also be in place so this is built on the final CLI architecture.
+
+## How `bun create` resolves
+
+`bun create <name> <dir>` (and the npm/yarn/pnpm `create` equivalents) resolves the npm package **`create-<name>`** and runs its `bin`. So this requires publishing a package named **`create-init-now`**.
+
+## 1. The `create-init-now` package
+
+Keep it a **thin wrapper** — no logic duplication:
+
+- New directory `cli/create/` (or `create-init-now/` sibling to `cli/` — pick whichever keeps release-please path config simplest; it is template-internal either way).
+- `package.json`: name `create-init-now`, a single `bin` entry, `dependencies: { "init-now": "<version>" }`.
+- The bin simply delegates to the `init-now` root command (scaffold flow), forwarding argv: `import "init-now/dist/index.js"`-style shim or spawning the resolved bin. Verify `init-now`'s package exports allow programmatic/bin reuse; add an export if needed.
+- No own build step if possible (plain JS shim); no own lockfile ceremony beyond what publishing requires.
+
+Version strategy: `create-init-now` joins the **lockstep version group** from plan 08 (`init` + `init-now` + `create-init-now` share one version via release-please's `linked-versions` plugin), with its `init-now` dependency pinned to that same version. A small release-workflow step (or the release PR itself) syncs the dependency pin each release.
+
+## 2. Release automation (extends plan 08)
+
+- Add `create-init-now` to `release-please-config.json` (own component/tag) or, simpler, publish it from the same workflow step that publishes `init-now`, with its version + dependency synced to the CLI version programmatically before `npm publish`. Prefer whichever needs less config to keep in lockstep — evaluate both, document the choice in `cli/README.md`.
+- Publish gate: same as `init-now` (tests + build green).
+- Smoke test in CI (can live in the CLI workflow from plan 09): `bun create init-now@latest tmp-app` against the freshly packed tarballs (`bun pm pack` + install from file) asserting the scaffold flow starts (e.g., `--help`/`--version` of the shim resolves and prints).
+
+## 3. Template-internal hygiene
+
+- The wrapper directory joins the internal-files story: `cleanupInternalFiles` in `cli/src/commands/setup.ts`, plan 04's manifest `internalPaths`, and the cleanup-list test from plan 09 §5. (If it lives under `cli/`, it is already covered by the existing `cli` entry — verify.)
+- Update docs after landing: `cli/README.md` and the root `README.md` getting-started section switch the canonical command to `bun create init-now my-app` (keep `bunx init-now@latest` documented as equivalent).
+- Update the marketing page command (plan 10 site) in the same PR.
+
+## Acceptance criteria
+
+- `bun create init-now my-app` scaffolds a project identically to `bunx init-now@latest my-app` (same prompts, same output).
+- `npm create init-now@latest my-app` works (verifies the cross-package-manager path).
+- Publishing is automated: a CLI release produces matching `init-now` and `create-init-now` versions on npm with the wrapper depending on the exact released version.
+- Scaffolded projects contain no trace of the wrapper package.
+- Marketing page and READMEs show `bun create init-now my-app` as the primary command.

--- a/.plans/12-agents-context-docs-refactor.md
+++ b/.plans/12-agents-context-docs-refactor.md
@@ -1,0 +1,54 @@
+# Plan 12 — AGENTS.md → AGENTS.md + CONTEXT.md + docs refactor
+
+Restructure this repo's agent-facing documentation from one overloaded `AGENTS.md` into the layered setup: **`AGENTS.md`** (standing rules and commands) + **`CONTEXT.md`** (domain language and orientation) + **`docs/`** (agent workflow docs, ADRs). This is the layout the maintainer's engineering skills expect (`setup-matt-pocock-skills`, consumed by `domain-modeling`, `triage`, `grilling`, etc. — see `~/.agents/skills/setup-matt-pocock-skills/SKILL.md`), and **`../adamantite` is the live reference implementation** (its `AGENTS.md`, `CONTEXT.md`, and `docs/agents/` show the target shape).
+
+## The split
+
+Roles, per the skill's model:
+
+- **`AGENTS.md`** — standing rules only: quality-control commands (format/check/analyze/test), comment policy, version control, coding style, import rules. Short. Points to `CONTEXT.md` and `docs/agents/*` instead of inlining everything. See `../adamantite/AGENTS.md` — note how it opens with skill wiring (issue tracker, triage labels, domain docs) in a few lines each, with details delegated to `docs/agents/*.md`.
+- **`CONTEXT.md`** — _what things mean_, not rules: what init is, the glossary (template vs scaffolded project, workspace, registry item, manifest, internal paths, backend alternatives, preset, ...), architectural orientation (apps/packages/tooling flow, unidirectional imports **as a concept**), and pointers to ADRs. See `../adamantite/CONTEXT.md` for tone: "Read this before exploring or changing code so you use the project's own terms."
+- **`docs/agents/`** — skill wiring docs: `issue-tracker.md`, `triage-labels.md`, `domain.md` (consumer rules for the domain docs).
+- **`docs/adr/`** — architectural decision records. Seed it with the decisions already made in these plans, so they stop living only in `.plans/`:
+  - Convex backend lives in `packages/`, is an alternative to `apps/api` (plan 05's AGENTS.md carve-out becomes an ADR + a glossary entry)
+  - Package vs registry-item criterion (plans README / 07)
+  - Zero-external-services-by-default principle
+  - Desktop is local-first by default (plan 03 §4b)
+  - files-sdk adoption direction (from `docs/research/files-sdk.md`, when acted on)
+
+## Single- vs multi-context
+
+**Decided: single-context** (one root `CONTEXT.md` + `docs/adr/`). This repo is a monorepo, but it's one product (the template) with one domain language; per-workspace CONTEXT files would mostly restate the root. Revisit multi-context (`CONTEXT-MAP.md` + per-context files) only if the CLI (`cli/`) or the site (`www/`) develop enough independent vocabulary — `cli/` is the most likely candidate.
+
+Consider running the `setup-matt-pocock-skills` skill to scaffold section A–C choices interactively rather than hand-writing them.
+
+## Content migration map
+
+From the current `AGENTS.md`:
+
+| Current AGENTS.md section                                                                 | Destination                                                                                                                                                                                        |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Project Structure (folder meanings, import flow rationale)                                | `CONTEXT.md` (meaning) + keep a terse rules bullet in `AGENTS.md` (enforcement)                                                                                                                    |
+| Testing, Comment Policy, Version Control, Coding Style, Imports, Naming, TS Usage, Syntax | stay in `AGENTS.md` (rules) — tighten wording                                                                                                                                                      |
+| Database / Expo / Hono / Web UI sections                                                  | stay in `AGENTS.md`, or move to scoped `AGENTS.md` files per directory if supported tooling prefers colocation — keep whichever is shorter                                                         |
+| Adamantite managed block                                                                  | stays in `AGENTS.md` (it's command rules; the block is tool-managed)                                                                                                                               |
+| Stale claims                                                                              | fix during migration: `scripts/` described as containing the template-sync script (sync lives in the `init-now` CLI; `scripts/` is deleted by plan 02); any other drift found while moving content |
+
+Also update `docs/project-structure.md` and the template `README.md` to stay consistent (plan 05 already touches the backend parts — coordinate, don't duplicate).
+
+## Template implications (this repo is a template!)
+
+Scaffolded projects inherit these files. Decide per file:
+
+- `AGENTS.md`, `CONTEXT.md` — **ship to users**: new projects start with the layout, the glossary, and the standing rules; users' agents then maintain them.
+- `docs/adr/` — **template-internal, stripped on install** (decided). The ADRs record why the _template_ is shaped the way it is (backend-in-packages, package-vs-registry criterion, desktop local-first, ...) — essential for agents evolving the template, irrelevant-to-misleading inside a consumer project. Add `docs/adr/` to `cleanupInternalFiles`, plan 04's manifest `internalPaths`, and plan 09 §5's cleanup-list test. Consumers create their own `docs/adr/` lazily via the `domain-modeling` skill when their first decision lands.
+  - Consequence for `CONTEXT.md`: since it ships but the ADRs don't, any consumer-relevant decision must be _summarized inline_ in CONTEXT.md (glossary/orientation entries, e.g. what the backend alternative means), with ADR links kept in a clearly template-only section or phrased so their removal doesn't leave dangling references. Template-only docs referenced by CONTEXT.md (e.g. `docs/research/*`) follow the same rule: keep in template, strip on install, never load-bearing for the shipped text.
+- `docs/agents/issue-tracker.md`, `triage-labels.md` — these encode _this repo's_ tracker (`metaideas/init`). **Decided: strip via CLI cleanup** — add both to `cleanupInternalFiles` (`cli/src/commands/setup.ts`), plan 04's manifest `internalPaths`, and plan 09 §5's cleanup-list test. Scaffolded projects run `setup-matt-pocock-skills` themselves to generate their own; the shipped `AGENTS.md` should note that.
+- `CLAUDE.md`/`.cursorrules`-style duplicates: none exist today — keep it that way; `AGENTS.md` is the single agent entrypoint.
+
+## Acceptance criteria
+
+- `AGENTS.md` contains only standing rules + pointers; `CONTEXT.md` exists with glossary and orientation; `docs/agents/` + `docs/adr/` exist with at least the seed ADRs listed above.
+- No stale claims: `rg "syncing the project with the template" AGENTS.md docs/` returns nothing pointing at `scripts/`.
+- The maintainer's skills work against the layout: `domain-modeling` finds `CONTEXT.md`/`docs/adr/`, `triage` finds the label vocabulary doc.
+- A scaffolded project receives a coherent doc set: `AGENTS.md` + `CONTEXT.md` with no dangling references — no `docs/adr/`, no tracker docs, no references to template-internal machinery (`.plans/`, `cli/`, `www/`, `docs/research/`, registry publishing).

--- a/.plans/README.md
+++ b/.plans/README.md
@@ -1,0 +1,45 @@
+# Template Improvement Plans
+
+Plans for evolving the `init` template monorepo and its `init-now` CLI. Each plan is self-contained and can be handed to an agent independently, but respect the ordering constraints below.
+
+## Plans
+
+| #   | Plan                                                                         | Depends on           | Size |
+| --- | ---------------------------------------------------------------------------- | -------------------- | ---- |
+| 01  | [CLI correctness fixes](01-cli-correctness-fixes.md)                         | —                    | S    |
+| 02  | [Package consolidation & dead-code sweep](02-package-consolidation.md)       | —                    | M    |
+| 03  | [App hygiene](03-app-hygiene.md)                                             | —                    | M    |
+| 04  | [CLI manifest & setup rework](04-cli-manifest-and-setup.md)                  | 01, 02, 09           | L    |
+| 05  | [Convex backend example & conventions](05-convex-backend-example.md)         | 02                   | S    |
+| 06  | [Update command rework](06-update-command-rework.md)                         | 01, 04, 09           | L    |
+| 07  | [Registry (init.now)](07-registry.md)                                        | 02, 04, 10           | L    |
+| 08  | [CLI release automation](08-cli-release-automation.md)                       | 01, 09               | S    |
+| 09  | [CLI: Effect v4, adamantite, CI](09-cli-effect-v4-and-tooling.md)            | 01                   | L    |
+| 10  | [init.now marketing site](10-marketing-site.md)                              | —                    | M    |
+| 11  | [`bun create init-now` support](11-bun-create-support.md)                    | 08, 09               | S    |
+| 12  | [AGENTS.md + CONTEXT.md + docs refactor](12-agents-context-docs-refactor.md) | 02 (soft), 05 (soft) | M    |
+
+01, 02, 03, and 10 can run in parallel. 09 follows 01 and precedes the CLI feature work (04, 06, 08) so new code is written against Effect v4 and passes the CLI's own adamantite checks/CI. 06 builds on 04's manifest. 07 is last — it consumes the "registry backlog" items that 02/03 remove from the template and is hosted on the site built in 10.
+
+## Context (shared by all plans)
+
+- This repo is a template monorepo. Users scaffold projects from it with the `init-now` CLI (source in `cli/`, published to npm separately — `cli/` is NOT part of the root Bun workspaces).
+- Guiding principle: **the template ships a wired, consumed core with zero required external services**. Optional capability lives in selectable packages (chosen during `init-now setup`) or, eventually, a hosted registry (plan 07). Local dev must work with `docker compose` alone — no accounts, no API keys.
+- Packages vs registry criterion (decided):
+  - **Package** = ongoing dependency with its own third-party deps and lifecycle (payments, ai, analytics, kv, email client). These stay, even with zero in-template consumers, because the CLI lets users select them.
+  - **Registry item** = copy-once code the user owns after install (email templates, one-off utils, extra UI components, auth integration snippets, env presets).
+- `packages/backend` (Convex) stays in `packages/` — it is consumed like a library (client + generated types) and deploys to Convex cloud, not our infra. It is an intentional _alternative_ to `apps/api`, not dead code.
+- **Lockstep versioning (decided)**: the template (`init`), the CLI (`init-now`), and later `create-init-now` share one version number via release-please linked versions (plan 08). CLI-only releases produce no-op template updates, handled gracefully by `update` (plan 06).
+
+## Verification (run after any code change)
+
+```sh
+bun run format      # adamantite format
+bun run check       # lint + typecheck
+bun run analyze     # knip dead-code/dep analysis
+bun run check:monorepo
+bun test            # root workspaces
+cd cli && bun test  # CLI has its own lockfile/tests
+```
+
+Use conventional commits (`feat:`, `fix:`, `chore:`, `refactor:`, ...).


### PR DESCRIPTION
Adds a `.plans/` directory containing twelve structured improvement plans for the `init` template monorepo and its `init-now` CLI, along with a README that summarizes their ordering and shared context.

The plans cover:

- **Plan 01** — Bug fixes in the CLI: broken overwrite behavior, hardcoded version string, tag format parsing errors in `compareVersions`, `.template-version.json` corruption, a dead branch in the `check` command, a duplicated `updatePackageJson` implementation, stale exclusion lists, and minor dead code.
- **Plan 02** — Merging `@init/error` into `@init/core`, deleting `@init/storage` and decoupling its types from the database schema, and a broad dead-code sweep across packages, tooling, and root-level infrastructure including the `scripts/` directory.
- **Plan 03** — App-level hygiene: error boundaries, wiring the forgot-password flow through `@init/email`, fixing broken env modules in `apps/web` and `apps/extension`, removing placeholder and dead-weight code across all apps, making `apps/desktop` local-first by default, and seeding meaningful tests and CI improvements.
- **Plan 04** — Replacing the hardcoded workspace list with a generated `manifest.json`, adding transitive dependency resolution to `init-now setup`, introducing an explicit backend choice prompt, pinning scaffolded projects to a release tag, and adding full non-interactive flag support.
- **Plan 05** — Adding a minimal `packages/backend` (Convex) consumption example in `apps/mobile`, reducing duplication between the two backend stacks, and documenting the `packages/` placement convention for hosted-platform backends.
- **Plan 06** — Reworking `init-now update` into a base-aware three-way file classification that handles conflicts, upstream deletions, rename idempotency, internal-path exclusion, and dry-run support.
- **Plan 07** — Building a hosted code registry at `init.now/r/` using the shadcn registry schema, populating it with items removed in Plans 02/03, and adding `init-now add` support with scope rewriting. Includes detailed requirements for a `files-sdk` storage integration recipe.
- **Plan 08** — Automating CLI versioning and npm publishing via release-please linked versions, establishing lockstep versioning across `init`, `init-now`, and later `create-init-now`, and eliminating all hardcoded version strings.
- **Plan 09** — Migrating the CLI to Effect v4 beta, restructuring it to match the `adamantite` reference layout, adding adamantite lint/format/typecheck tooling local to `cli/`, adding a dedicated GitHub Actions workflow, and hardening error handling and input validation.
- **Plan 10** — Creating a barebones `www/` marketing site for `init.now` (Astro, Vercel), reserving stable `/registry` and `/r/*` routes for the registry, and ensuring `www/` is stripped from scaffolded projects.
- **Plan 11** — Publishing a thin `create-init-now` wrapper package so `bun create init-now` works, joining it to the lockstep version group, and updating docs and the marketing page accordingly.
- **Plan 12** — Splitting the overloaded `AGENTS.md` into `AGENTS.md` (standing rules), `CONTEXT.md` (domain glossary and orientation), `docs/agents/` (skill wiring docs), and `docs/adr/` (architectural decision records seeded from decisions made across these plans), with clear rules about which files ship to scaffolded projects and which are stripped.