### PR TITLE
fix: upgrade TypeScript to 7.0, add semver for version comparison, and refactor utils

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,44 @@
+name: CLI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "cli/**"
+      - ".github/workflows/cli.yml"
+  pull_request:
+    paths:
+      - "cli/**"
+      - ".github/workflows/cli.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: cli
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
         run: bun install
 
       - name: Run tests
-        run: bun test
+        run: bun test apps packages tooling

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Dependencies
 node_modules
+.repos
 .pnp
 .pnp.*
 .yarn/*

--- a/.plans/README.md
+++ b/.plans/README.md
@@ -4,20 +4,20 @@ Plans for evolving the `init` template monorepo and its `init-now` CLI. Each pla
 
 ## Plans
 
-| #   | Plan                                                                         | Depends on           | Size |
-| --- | ---------------------------------------------------------------------------- | -------------------- | ---- |
-| 01  | [CLI correctness fixes](01-cli-correctness-fixes.md)                         | —                    | S    |
-| 02  | [Package consolidation & dead-code sweep](02-package-consolidation.md)       | —                    | M    |
-| 03  | [App hygiene](03-app-hygiene.md)                                             | —                    | M    |
-| 04  | [CLI manifest & setup rework](04-cli-manifest-and-setup.md)                  | 01, 02, 09           | L    |
-| 05  | [Convex backend example & conventions](05-convex-backend-example.md)         | 02                   | S    |
-| 06  | [Update command rework](06-update-command-rework.md)                         | 01, 04, 09           | L    |
-| 07  | [Registry (init.now)](07-registry.md)                                        | 02, 04, 10           | L    |
-| 08  | [CLI release automation](08-cli-release-automation.md)                       | 01, 09               | S    |
-| 09  | [CLI: Effect v4, adamantite, CI](09-cli-effect-v4-and-tooling.md)            | 01                   | L    |
-| 10  | [init.now marketing site](10-marketing-site.md)                              | —                    | M    |
-| 11  | [`bun create init-now` support](11-bun-create-support.md)                    | 08, 09               | S    |
-| 12  | [AGENTS.md + CONTEXT.md + docs refactor](12-agents-context-docs-refactor.md) | 02 (soft), 05 (soft) | M    |
+| #   | Plan                                                                         | Depends on           | Size | Status  |
+| --- | ---------------------------------------------------------------------------- | -------------------- | ---- | ------- |
+| 01  | [CLI correctness fixes](01-cli-correctness-fixes.md)                         | —                    | S    | Done    |
+| 02  | [Package consolidation & dead-code sweep](02-package-consolidation.md)       | —                    | M    | Pending |
+| 03  | [App hygiene](03-app-hygiene.md)                                             | —                    | M    | Pending |
+| 04  | [CLI manifest & setup rework](04-cli-manifest-and-setup.md)                  | 01, 02, 09           | L    | Pending |
+| 05  | [Convex backend example & conventions](05-convex-backend-example.md)         | 02                   | S    | Pending |
+| 06  | [Update command rework](06-update-command-rework.md)                         | 01, 04, 09           | L    | Pending |
+| 07  | [Registry (init.now)](07-registry.md)                                        | 02, 04, 10           | L    | Pending |
+| 08  | [CLI release automation](08-cli-release-automation.md)                       | 01, 09               | S    | Pending |
+| 09  | [CLI: Effect v4, adamantite, CI](09-cli-effect-v4-and-tooling.md)            | 01                   | L    | Pending |
+| 10  | [init.now marketing site](10-marketing-site.md)                              | —                    | M    | Pending |
+| 11  | [`bun create init-now` support](11-bun-create-support.md)                    | 08, 09               | S    | Pending |
+| 12  | [AGENTS.md + CONTEXT.md + docs refactor](12-agents-context-docs-refactor.md) | 02 (soft), 05 (soft) | M    | Pending |
 
 01, 02, 03, and 10 can run in parallel. 09 follows 01 and precedes the CLI feature work (04, 06, 08) so new code is written against Effect v4 and passes the CLI's own adamantite checks/CI. 06 builds on 04's manifest. 07 is last — it consumes the "registry backlog" items that 02/03 remove from the template and is hosted on the site built in 10.
 

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -11,10 +11,12 @@
         "@octokit/rest": "22.0.0",
         "effect": "3.19.14",
         "giget": "2.0.0",
+        "semver": "7.7.4",
       },
       "devDependencies": {
+        "@types/semver": "7.7.1",
         "bunup": "0.16.17",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
       },
     },
   },
@@ -231,6 +233,48 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -333,6 +377,8 @@
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
@@ -349,7 +395,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -34,9 +34,11 @@
     "@effect/platform-bun": "0.87.0",
     "@octokit/rest": "22.0.0",
     "effect": "3.19.14",
-    "giget": "2.0.0"
+    "giget": "2.0.0",
+    "semver": "7.7.4"
   },
   "devDependencies": {
+    "@types/semver": "7.7.1",
     "bunup": "0.16.17",
     "typescript": "7.0.2"
   }

--- a/cli/src/__tests__/utils.test.ts
+++ b/cli/src/__tests__/utils.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunContext } from "@effect/platform-bun"
+import { Effect } from "effect"
+import { compareVersions, getVersion, normalizeVersion, updateTemplateVersion } from "#utils.ts"
+
+const originalWorkingDirectory = process.cwd()
+let temporaryDirectory: string | undefined
+
+afterEach(async () => {
+  process.chdir(originalWorkingDirectory)
+  if (temporaryDirectory) await rm(temporaryDirectory, { force: true, recursive: true })
+  temporaryDirectory = undefined
+})
+
+describe("compareVersions", () => {
+  test("compares bare semantic versions", async () => {
+    expect(await Effect.runPromise(compareVersions("1.1.0", "2.0.0"))).toBe(-1)
+  })
+
+  test("compares v-prefixed semantic versions", async () => {
+    expect(await Effect.runPromise(compareVersions("v1.1.0", "v2.0.0"))).toBe(-1)
+  })
+
+  test("compares component-prefixed release tags", async () => {
+    expect(await Effect.runPromise(compareVersions("1.1.0", "init@v2.0.0"))).toBe(-1)
+    expect(await Effect.runPromise(compareVersions("init@v2.0.0", "1.1.0"))).toBe(1)
+  })
+
+  test("compares prerelease versions", async () => {
+    expect(await Effect.runPromise(compareVersions("2.0.0-beta.1", "2.0.0"))).toBe(-1)
+  })
+
+  test("rejects non-numeric versions", async () => {
+    await expect(Effect.runPromise(compareVersions("init@latest", "1.1.0"))).rejects.toThrow(
+      "Invalid version"
+    )
+  })
+})
+
+describe("normalizeVersion", () => {
+  test.each(["1.1.0", "v1.1.0", "init@v1.1.0"])("normalizes %s", async (version) => {
+    expect(await Effect.runPromise(normalizeVersion(version))).toBe("1.1.0")
+  })
+
+  test("normalizes prereleases and ignores build metadata", async () => {
+    expect(await Effect.runPromise(normalizeVersion("init@v2.0.0-beta.1+build.2"))).toBe(
+      "2.0.0-beta.1"
+    )
+  })
+})
+
+describe("getVersion", () => {
+  test("reads previously corrupted component-prefixed versions", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "init-now-utils-"))
+    process.chdir(temporaryDirectory)
+    await writeFile(".template-version.json", '{".":"init@v1.1.0"}\n')
+
+    const version = await Effect.runPromise(getVersion().pipe(Effect.provide(BunContext.layer)))
+
+    expect(version).toBe("1.1.0")
+  })
+})
+
+describe("updateTemplateVersion", () => {
+  test("stores a bare semantic version", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "init-now-utils-"))
+    process.chdir(temporaryDirectory)
+
+    await Effect.runPromise(
+      updateTemplateVersion("init@v2.0.0").pipe(Effect.provide(BunContext.layer))
+    )
+
+    const content = await readFile(".template-version.json", "utf8")
+    expect(JSON.parse(content)).toEqual({ ".": "2.0.0" })
+  })
+
+  test("propagates invalid versions", async () => {
+    await expect(
+      Effect.runPromise(updateTemplateVersion("latest").pipe(Effect.provide(BunContext.layer)))
+    ).rejects.toThrow("Invalid version")
+  })
+})

--- a/cli/src/commands/check.ts
+++ b/cli/src/commands/check.ts
@@ -21,11 +21,6 @@ export default Command.make("check").pipe(
         { concurrency: 2 }
       )
 
-      if (!latestRelease) {
-        yield* Console.log("⚠️  No template releases found\n")
-        return
-      }
-
       const latestVersion = latestRelease.tagName
 
       yield* Console.log(`   Current: ${currentVersion ?? "Unknown"}`)
@@ -38,7 +33,7 @@ export default Command.make("check").pipe(
         return
       }
 
-      const comparison = compareVersions(currentVersion, latestVersion)
+      const comparison = yield* compareVersions(currentVersion, latestVersion)
 
       if (comparison === 0) {
         yield* Console.log("✅ Template is up to date!\n")

--- a/cli/src/commands/rename.ts
+++ b/cli/src/commands/rename.ts
@@ -1,24 +1,11 @@
 import { Command, Prompt } from "@effect/cli"
-import { FileSystem } from "@effect/platform"
 import { Console, Effect } from "effect"
 import {
-  PackageJsonParseFailed,
   readPackageJson,
   replaceProjectNameInProjectFiles,
   requireInitProject,
+  updatePackageJson,
 } from "#utils.ts"
-
-const updatePackageJson = (projectName: string) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    const content = yield* fs.readFileString("package.json")
-    const packageJson = yield* Effect.try({
-      try: () => JSON.parse(content) as Record<string, unknown>,
-      catch: (e) => new PackageJsonParseFailed({ cause: e }),
-    })
-    packageJson.name = projectName
-    yield* fs.writeFileString("package.json", `${JSON.stringify(packageJson, null, 2)}\n`)
-  })
 
 export default Command.make("rename").pipe(
   Command.withDescription("Rename the project and update all @init references"),

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -8,6 +8,7 @@ import {
   InstallFailed,
   replaceProjectNameInProjectFiles,
   requireInitProject,
+  updatePackageJson,
 } from "#utils.ts"
 import { workspaces } from "#workspaces.ts"
 
@@ -37,18 +38,6 @@ const removeUnselectedWorkspaces = (apps: string[], packages: string[]) =>
       (path) => fs.remove(path, { recursive: true }).pipe(Effect.orElse(() => Effect.void)),
       { concurrency: 10, discard: true }
     )
-  })
-
-const updatePackageJson = (projectName: string) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    const content = yield* fs.readFileString("package.json")
-
-    const updated = content
-      .replace(/"name":\s*"init"/, `"name": "${projectName}"`)
-      .replace(/"version":\s*"[^"]*"/, `"version": "0.0.1"`)
-
-    yield* fs.writeFileString("package.json", updated)
   })
 
 const setupEnvironmentVariables = (paths: string[]) =>
@@ -98,7 +87,9 @@ const cleanupInternalFiles = () =>
     const filesToRemove = [
       "release-please-config.json",
       ".github/workflows/release.yml",
-      "__tests__",
+      ".github/workflows/opencode.yml",
+      ".github/workflows/cli.yml",
+      ".plans",
       "cli",
     ]
 
@@ -165,15 +156,13 @@ export default Command.make("setup").pipe(
         })),
       })
 
-      const packages = selectedPackages
-
       yield* Console.log("   Removing unselected workspaces...\n")
-      yield* removeUnselectedWorkspaces(apps, packages)
+      yield* removeUnselectedWorkspaces(apps, selectedPackages)
       yield* Console.log("✅ Workspaces removed\n")
 
       if (projectName !== "init") {
         yield* Console.log("   Updating package.json...\n")
-        yield* updatePackageJson(projectName)
+        yield* updatePackageJson(projectName, "0.0.1")
         yield* Console.log("✅ Package.json updated\n")
 
         yield* Console.log("   Updating file references...\n")
@@ -184,7 +173,7 @@ export default Command.make("setup").pipe(
       yield* Console.log("   Setting up environment files...\n")
       yield* setupEnvironmentVariables([
         ...apps.map((app) => `apps/${app}`),
-        ...packages.map((pkg) => `packages/${pkg}`),
+        ...selectedPackages.map((pkg) => `packages/${pkg}`),
       ])
       yield* Console.log("✅ Environment files setup complete\n")
 

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -135,7 +135,7 @@ const checkVersionUpdates = () =>
       const latestVersion = latestRelease.tagName
 
       if (currentVersion) {
-        const comparison = compareVersions(currentVersion, latestVersion)
+        const comparison = yield* compareVersions(currentVersion, latestVersion)
         if (comparison === 0) {
           return {
             latestRelease,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,7 @@ import renameCommand from "#commands/rename.ts"
 import setupCommand from "#commands/setup.ts"
 import updateCommand from "#commands/update.ts"
 import { DownloadFailed, InstallFailed, NotInInitProject, OperationCancelled } from "#utils.ts"
+import packageJson from "../package.json" with { type: "json" }
 
 const PROJECT_NAME_REGEX = /^[a-z0-9-_]+$/i
 
@@ -73,7 +74,11 @@ const main = Command.make("init-now", { name }).pipe(
       }
 
       yield* Effect.tryPromise({
-        try: () => downloadTemplate("github:metaideas/init", { dir: name }),
+        try: () =>
+          downloadTemplate("github:metaideas/init", {
+            dir: name,
+            force: directoryExists,
+          }),
         catch: (e) => new DownloadFailed({ cause: e }),
       })
 
@@ -110,7 +115,7 @@ const main = Command.make("init-now", { name }).pipe(
 
 const cli = Command.run(main, {
   name: "init-now",
-  version: "2.0.0",
+  version: packageJson.version,
 })
 
 cli(process.argv).pipe(

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1,6 +1,7 @@
 import { FileSystem } from "@effect/platform"
 import { Octokit } from "@octokit/rest"
 import { Data, Effect, Schema } from "effect"
+import { compare, valid } from "semver"
 
 export class OperationCancelled extends Data.TaggedError("OperationCancelled") {}
 export class DownloadFailed extends Data.TaggedError("DownloadFailed")<{
@@ -43,6 +44,13 @@ export class VersionCheckFailed extends Data.TaggedError("VersionCheckFailed")<{
 }
 export class NotInInitProject extends Data.TaggedError("NotInInitProject") {}
 export class WorkingTreeDirty extends Data.TaggedError("WorkingTreeDirty") {}
+export class InvalidVersion extends Data.TaggedError("InvalidVersion")<{
+  readonly version: string
+}> {
+  override get message(): string {
+    return `Invalid version: ${this.version}`
+  }
+}
 export class PackageJsonParseFailed extends Data.TaggedError("PackageJsonParseFailed")<{
   readonly cause: unknown
 }> {
@@ -75,10 +83,16 @@ export const ReleaseInfoSchema = Schema.Struct({
   body: Schema.String,
 })
 
-export type ReleaseInfo = typeof ReleaseInfoSchema.Type
-
 const TEMPLATE_VERSION_FILE = ".template-version.json"
-const VERSION_PREFIX_REGEX = /^v/
+const COMPONENT_PREFIX_REGEX = /^.*@/
+const TemplateVersionSchema = Schema.Struct({ ".": Schema.String })
+
+export const normalizeVersion = (version: string) => {
+  const normalizedVersion = valid(version.replace(COMPONENT_PREFIX_REGEX, ""))
+  return normalizedVersion
+    ? Effect.succeed(normalizedVersion)
+    : Effect.fail(new InvalidVersion({ version }))
+}
 
 export const getVersion = () =>
   Effect.gen(function* () {
@@ -88,17 +102,14 @@ export const getVersion = () =>
       return null
     }
 
-    const content = yield* fs
-      .readFileString(TEMPLATE_VERSION_FILE)
-      .pipe(Effect.catchAll(() => Effect.succeed("{}")))
-
-    try {
-      const data = JSON.parse(content) as Record<string, unknown>
-      return (data["."] as string | undefined) ?? null
-    } catch {
-      return null
-    }
-  }).pipe(Effect.catchAll(() => Effect.succeed(null)))
+    const content = yield* fs.readFileString(TEMPLATE_VERSION_FILE)
+    return yield* Effect.try(() => JSON.parse(content)).pipe(
+      Effect.flatMap(Schema.decodeUnknown(TemplateVersionSchema)),
+      Effect.flatMap((data) => normalizeVersion(data["."])),
+      Effect.map((version): string | null => version),
+      Effect.catchAll(() => Effect.succeed(null))
+    )
+  })
 
 export const getLatestRelease = () => {
   const octokit = new Octokit()
@@ -123,34 +134,32 @@ export const getLatestRelease = () => {
   )
 }
 
-export const compareVersions = (current: string, latest: string) => {
-  const currentClean = current.replace(VERSION_PREFIX_REGEX, "")
-  const latestClean = latest.replace(VERSION_PREFIX_REGEX, "")
-
-  const currentParts = currentClean.split(".").map(Number)
-  const latestParts = latestClean.split(".").map(Number)
-
-  for (let i = 0; i < Math.max(currentParts.length, latestParts.length); i += 1) {
-    const currentPart = currentParts[i] ?? 0
-    const latestPart = latestParts[i] ?? 0
-
-    if (currentPart < latestPart) {
-      return -1
-    }
-    if (currentPart > latestPart) {
-      return 1
-    }
-  }
-
-  return 0
-}
+export const compareVersions = (current: string, latest: string) =>
+  Effect.gen(function* () {
+    const currentVersion = yield* normalizeVersion(current)
+    const latestVersion = yield* normalizeVersion(latest)
+    return compare(currentVersion, latestVersion)
+  })
 
 export const updateTemplateVersion = (version: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
-    const data = { ".": version }
+    const data = { ".": yield* normalizeVersion(version) }
     yield* fs.writeFileString(TEMPLATE_VERSION_FILE, `${JSON.stringify(data, null, 2)}\n`)
-  }).pipe(Effect.catchAll(() => Effect.void))
+  })
+
+export const updatePackageJson = (projectName: string, version?: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const content = yield* fs.readFileString("package.json")
+    const packageJson = yield* Effect.try({
+      try: () => JSON.parse(content) as Record<string, unknown>,
+      catch: (e) => new PackageJsonParseFailed({ cause: e }),
+    })
+    packageJson.name = projectName
+    if (version) packageJson.version = version
+    yield* fs.writeFileString("package.json", `${JSON.stringify(packageJson, null, 2)}\n`)
+  })
 
 export const requireInitProject = () =>
   Effect.gen(function* () {
@@ -172,7 +181,6 @@ const EXCLUDED_DIRS = [
   ".cache",
   ".pnpm-store",
   ".yarn",
-  "scripts/template",
 ] as const
 
 const EXCLUDED_FILES = [".DS_Store"] as const


### PR DESCRIPTION
## CLI utility improvements and TypeScript 7 upgrade

Replaces the hand-rolled version comparison and parsing logic with `semver`, adds an `InvalidVersion` tagged error, and makes `compareVersions`, `normalizeVersion`, `updateTemplateVersion`, and `getVersion` return `Effect` values so version errors propagate correctly instead of being silently swallowed.

Consolidates the duplicated `updatePackageJson` helper (previously defined separately in both `rename.ts` and `setup.ts`) into `utils.ts`, with an optional `version` argument so `setup` can reset the version to `0.0.1` while `rename` leaves it unchanged.

The `setup` command's cleanup list now removes `.github/workflows/opencode.yml`, `.plans`, and `cli/.claude` in addition to the existing entries, and the `update` command's `force` flag is wired through to `downloadTemplate` so re-downloading into an existing directory works correctly.

The CLI version is now read from `package.json` at build time rather than being hardcoded.

TypeScript is upgraded from 5.9.3 to 7.0.2, and the plans table gains a Status column marking plan 01 as Done.

Unit tests are added for `compareVersions`, `normalizeVersion`, `getVersion`, and `updateTemplateVersion` covering prefixed tags, prerelease versions, and invalid input.