### PR TITLE
docs: plan Varlock validation and adoption

### DIFF
--- a/.plans/17-varlock-validation.md
+++ b/.plans/17-varlock-validation.md
@@ -1,0 +1,320 @@
+# Plan 17 — Validate Varlock across init
+
+**Status:** Planned
+**Size:** M
+
+Determine whether Varlock can replace T3 Env and init's custom environment-loading
+tooling across every selectable workspace without weakening type safety, secret
+boundaries, deployment behavior, or scaffold composition. Treat this as a decision
+gate: do not begin the repository-wide migration in Plan 18 until this plan records a
+passing result.
+
+The validation must prioritize the boundaries where framework ownership of the
+environment differs from ordinary Node or Vite applications: Expo and EAS, Convex,
+WXT, shared package workspaces, Tauri build variables, and external secret stores.
+Success is not merely getting `varlock load` to pass locally. The spike must prove that
+the same contract survives development, code generation, bundling, deployment, and
+runtime access without exposing sensitive values.
+
+## Questions to answer
+
+1. Can each application workspace own one complete `.env.schema` while importing
+   reusable contracts from selected package workspaces?
+2. Can shared packages such as `db`, `email`, `payments`, and `observability` use a
+   locally generated typed `ENV` while the consuming application initializes the
+   resolved Varlock graph?
+3. Do package-local generated modules avoid `ProcessEnv`, `ImportMetaEnv`, and global
+   `varlock/env` augmentation conflicts across the monorepo?
+4. Does Varlock preserve init's current parsing behavior, including booleans, ports,
+   URLs, defaults, optional values, arrays, regex-constrained strings, and values that
+   are required only in selected environments?
+5. Can every client-capable workspace distinguish bundle-safe configuration from
+   sensitive configuration without relying only on a naming prefix?
+6. Can CI and deployment validate real required values instead of using the current
+   `skipValidation: isCI` escape hatch?
+7. Can a supported secret store supply development and deployment values with a small,
+   well-defined secret-zero requirement and useful failure behavior?
+8. Does Varlock compose with init's workspace selection and cleanup behavior after a
+   scaffolded project no longer contains every application and package workspace?
+
+## 1. Establish the spike and baseline
+
+Record the current environment behavior before introducing Varlock:
+
+- inventory every key declared in `packages/env`, every application env module, every
+  `.env.template`, `turbo.json`, and every direct `process.env` or `import.meta.env`
+  access;
+- classify each key as sensitive or non-sensitive, build-time or runtime, required or
+  optional, and identify the workspace that owns the requirement;
+- identify duplicate and inconsistent declarations, including Expo configuration keys
+  that differ between `app.config.ts`, the Sentry preset, and `.env.template`;
+- capture representative success and failure output from the existing T3 Env setup;
+- note which commands rely on Bun, Expo, Vite, Astro, WXT, Tauri, Convex, Drizzle, or
+  another tool loading `.env` before application code runs.
+
+Implement the spike narrowly enough that it can be reviewed or removed independently.
+Do not delete `@init/env`, `@tooling/env`, `.env.template` files, or existing env modules
+during validation. Temporary integration code may live beside the current path, but
+the existing path remains the baseline until the decision gate passes.
+
+Write findings to `docs/template/research/varlock-validation.md`. Include exact tested
+versions, commands, relevant deployment targets, evidence links or captured output,
+and any result that could not be tested because it required unavailable credentials or
+infrastructure.
+
+## 2. Prove schema fidelity and generated types
+
+Create representative schemas covering the hardest existing rules:
+
+- `ALLOWED_API_ORIGINS` and `AUTH_TRUSTED_ORIGINS` as parsed arrays;
+- URL rules with HTTP-only, wildcard-origin, localhost, and custom-protocol cases;
+- `PORT` as a number/port and boolean defaults such as
+  `RUN_PRODUCTION_MIGRATIONS`, `MOCK_RESEND`, and Sentry debug flags;
+- optional values such as `INNGEST_BASE_URL`, S3 endpoint/region, and
+  `PUBLIC_API_URL`;
+- minimum-length secrets such as `FILES_API_SECRET`;
+- framework-provided Tauri variables that may be absent outside a Tauri command;
+- development-only defaults and production-only requirements.
+
+Generate package-local TypeScript modules with `exposeEnv=local` and no
+`process.env`/`import.meta.env` augmentation. Verify with type tests that values are
+coerced to their expected output types, unknown keys fail type checking on the local
+module, and generated declarations from different workspaces do not merge.
+
+Document any Zod behavior that cannot be represented faithfully in Varlock's schema
+language. Classify each mismatch as acceptable simplification, custom Varlock extension,
+or blocking loss of validation.
+
+## 3. Resolve schema ownership for shared packages
+
+Test a vertical slice containing an application and real shared package workspaces,
+not a standalone fixture. At minimum use:
+
+- `apps/api` with `packages/db` and `packages/email`;
+- `apps/mobile` with `packages/observability`;
+- one web client with `packages/payments` or another shared runtime consumer.
+
+Compare these ownership models:
+
+1. contracts centrally stored under `packages/env` and imported by applications;
+2. each package owning flat `env/<surface>.env` contract fragments plus a package
+   `.env.schema` and generated local module, with application schemas importing the
+   relevant package surfaces;
+3. application-only schemas with packages receiving configuration explicitly.
+
+Treat the second model as the preferred candidate. Use one fixed surface vocabulary:
+
+- `env/shared.env` for non-sensitive configuration used across runtimes;
+- `env/client.env` for configuration permitted in browser or native bundles;
+- `env/server.env` for server-runtime configuration;
+- `env/build.env` for build and deployment tooling.
+
+Packages create only applicable surface files but never invent package-specific surface
+names. A server-only package such as `packages/db` therefore owns
+`env/server.env`; a multi-surface package such as `packages/observability` may own all
+four. Do not introduce one directory per surface or generic names such as
+`env/preset.env`.
+
+Every independently runnable application owns a root `.env.schema` that imports the
+relevant package surface files and declares application-specific items. A configurable
+package may also own a root `.env.schema` for its commands and package-local type
+generation; reusable surface files must not carry root policy such as environment
+selection, default sensitivity, or application-specific generation paths.
+
+Prefer this package-owned model if it allows each selectable package to declare its own
+requirements without reintroducing a runtime dependency on `@init/env`. Prove that:
+
+- the package's generated `ENV` resolves against the consuming application's initialized
+  graph;
+- Vite and Metro transform `ENV.KEY` references inside workspace package source;
+- server-only package code cannot leak into browser, extension, desktop, or native
+  bundles;
+- tree-shaken optional package code does not make unrelated variables required;
+- schema imports remain valid after template setup removes unselected workspaces;
+- root decorators from package composition schemas cannot leak into applications that
+  import only the flat surface files;
+- the four surfaces are sufficient for existing packages without duplicating keys or
+  introducing framework-specific names such as `expo.env` by default;
+- Turbo and Adamantite understand the resulting package dependencies even though
+  Varlock schema imports are file references rather than TypeScript imports.
+
+The research report must select one ownership model before Plan 18 proceeds.
+
+## 4. Validate Expo, EAS, and Sentry
+
+Compose `@varlock/expo-integration` with the existing Expo Babel preset, Sentry Metro
+configuration, and Uniwind Metro wrapper. Exercise:
+
+- Expo development for iOS, Android, and web where locally available;
+- production JavaScript export and native prebuild;
+- an EAS development/preview build and production build when project credentials are
+  available;
+- EAS Update behavior, even though updates are currently disabled, to document whether
+  non-sensitive values are frozen into the update bundle;
+- Expo Router universal pages and a representative `+api` route;
+- `app.config.ts` values evaluated before Metro starts;
+- Sentry organization/project configuration and source-map upload using a sensitive
+  auth token.
+
+Demonstrate that a non-sensitive typed value is inlined and correctly coerced. Add a
+deliberate sensitive access in native code and confirm both build feedback and runtime
+failure. Confirm that a sensitive value can be used only in the intended server route.
+
+Inspect production JavaScript, source maps, Expo manifests, native generated files, and
+captured logs for known canary secrets. No canary secret may appear outside an
+explicitly approved server-side artifact. Record whether Expo config commands need
+`varlock run` in addition to the Babel/Metro integration.
+
+## 5. Validate Convex
+
+Convex is a deployment-owned runtime and must not be treated as ordinary Bun server
+code. Treat `packages/backend` as an intentional native exception rather than building
+a Varlock runtime or secret-synchronization adapter for deployed Convex functions.
+
+Use Convex's native environment declarations in `convex.config.ts`, its generated typed
+`env` object inside functions, and its deployment-owned environment values. Keep narrow
+local parsing for values whose application shape is richer than Convex's supported
+string/literal/union/optional validators. Use Convex system variables such as
+`CONVEX_SITE_URL` directly instead of redeclaring or synchronizing them.
+
+Prove that imported init packages do not need to bring their environment contracts into
+Convex. The preferred boundary is explicit configuration: `@init/auth` exposes factories
+and constants, while the Convex composition root declares `AUTH_SECRET` and
+`AUTH_TRUSTED_ORIGINS`, parses them locally, and passes them into the auth factory. Apply
+the same rule to future email, analytics, storage, or other integrations. If a package
+entrypoint reads environment variables internally, either refactor it to accept explicit
+configuration or record why the backend must declare the same requirement natively;
+do not import a Varlock surface into Convex merely to share a key name.
+
+Test:
+
+- `convex dev`, function bundling, code generation, and local dashboard values;
+- required, optional, and enum-like native declarations in `convex.config.ts`;
+- generated typed `env` access from queries, mutations, actions, and HTTP actions;
+- local parsing of `AUTH_TRUSTED_ORIGINS` and use of the guaranteed
+  `CONVEX_SITE_URL` system value;
+- validation failure before deployment when a required Convex value is absent;
+- distinct development, preview, and production deployment values using Convex's
+  native dashboard/CLI/default mechanisms;
+- coexistence between Convex-managed `.env.local` outputs and Varlock-managed
+  application environments without conflicting loaders or ownership;
+- application-side Convex URLs managed by each consuming application's Varlock schema
+  and updated by the existing backend-connection template command;
+- current and representative future backend package imports to confirm that they are
+  environment-independent or explicitly configured.
+
+The research report must describe Convex as an independent environment subsystem,
+including where its deployment values and deploy keys are configured. Do not require a
+Varlock schema, `varlock/env`, custom Varlock generator, or Varlock-to-Convex value sync
+for `packages/backend` unless this native model fails a concrete requirement during the
+spike.
+
+## 6. Validate WXT, Tauri, and standard integrations
+
+For WXT, add the Varlock Vite integration through WXT's supported configuration seam
+and build background, content-script, popup, and other selected entrypoints for Chrome
+and Firefox. Verify that public values are available in each intended entrypoint,
+sensitive values are rejected, and canary secrets are absent from distributable
+archives and source maps. If the ordinary Vite plugin is incompatible, determine the
+size and stability of the adapter required.
+
+For Tauri, confirm that Vite sees `TAURI_ENV_*` values supplied by Tauri commands,
+optional validation still works in ordinary tooling commands, and sensitive backend
+values cannot be bundled into the webview. Build or inspect both development and
+production configurations on an available target.
+
+Smoke-test the first-party Vite and Astro integrations against `apps/app`, `apps/web`,
+and `apps/docs`. Confirm SSR/runtime behavior for the actual deployment adapters rather
+than assuming all Vite applications are static clients.
+
+## 7. Validate secret-store and CI behavior
+
+Select at least one Varlock-supported secret-store integration that reflects intended
+init usage and can authenticate non-interactively in CI. The exact provider is not an
+upstream default unless the validation produces a compelling reason; scaffold owners
+must be able to choose another supported provider or plain deployment secrets.
+
+Verify:
+
+- local interactive authentication and non-interactive CI authentication;
+- the minimum secret-zero value required to resolve the remaining graph;
+- development, preview, and production separation;
+- actionable behavior when offline, unauthenticated, or denied access;
+- redaction from CLI output, application logs, build logs, cache artifacts, and error
+  reporting;
+- rotation without editing application source or schemas;
+- `varlock load` validation without unnecessarily exposing resolved secret values;
+- no resolved secret is committed in schemas, generated modules, fixtures, or snapshots.
+
+Add an `env:check` prototype that runs per workspace through Turbo. Determine whether
+Bun's automatic `.env` loading must be disabled globally or only for Varlock-managed
+commands, and test the effect on generators, tests, Drizzle, Expo, Convex, and local
+infrastructure scripts.
+
+## 8. Exercise scaffold selection
+
+Create disposable scaffolded projects representing at least:
+
+- API plus database/auth packages;
+- `apps/app` as an independently full-stack application without `apps/api` or another
+  application workspace;
+- Expo plus Convex;
+- Expo plus Hono API;
+- web-only static applications;
+- desktop or extension without the API;
+- a minimal project that omits the environment tooling workspace if that remains
+  selectable.
+
+Run setup, environment validation, type generation, checks, and targeted builds in each
+shape. No schema may import a removed workspace, and no generated module may retain a
+key from an unselected preset. Update the research report with the resulting schema
+composition rules that template commands must enforce.
+
+## Decision gate
+
+Finish the research report with one result: **Pass**, **Conditional pass**, or **Fail**.
+
+The result is **Pass** only when:
+
+- Expo/EAS, WXT, Convex, Tauri, Bun, Vite, and Astro have a proven path;
+- sensitive canary values are absent from all tested client artifacts and logs;
+- shared package ownership and local generated types work without global augmentation;
+- CI validates required deployment values instead of skipping them;
+- a secret-store workflow succeeds locally and non-interactively;
+- representative scaffolded project shapes validate and build;
+- no known blocker requires a maintained fork of Varlock.
+
+A **Conditional pass** may contain narrow, documented adapters for WXT or
+configuration-time tools, but every adapter must have an owner, tests, and an estimated
+maintenance cost. Convex's independently validated native environment subsystem is an
+intentional boundary, not a Varlock adapter. Moving forward from a conditional pass
+requires an explicit upstream template decision accepting the remaining exceptions.
+
+The result is **Fail** if any client can receive a sensitive value, deployment
+validation cannot be made reliable, package contracts cannot compose after workspace
+selection, or a critical integration depends on unstable internal APIs.
+
+If the result is Pass—or a Conditional pass is explicitly accepted—record the upstream
+decision in `docs/template/adr/` and change Plan 18 from gated to active. Otherwise,
+leave the current T3 Env path in place and record the rejected approach and evidence.
+
+## Verification
+
+The research report should contain the exact commands used. At minimum, run the
+applicable subset of:
+
+```sh
+bun run format
+bun run check
+bun run analyze
+bun run check:monorepo
+bun test
+bun run env:check
+bun run build --filter=api
+bun run build --filter=app
+bun run build --filter=mobile
+bun run build --filter=extension
+bun run build --filter=desktop
+bun run build --filter=web
+bun run build --filter=docs
+```

--- a/.plans/18-varlock-implementation.md
+++ b/.plans/18-varlock-implementation.md
@@ -1,0 +1,319 @@
+# Plan 18 — Adopt Varlock across init
+
+**Status:** Gated by Plan 17
+**Size:** L
+
+Replace T3 Env and init's overlapping environment loaders with Varlock after Plan 17
+records a Pass, or after an explicit upstream decision accepts a Conditional pass.
+Implement the schema ownership model, framework adapters, and deployment behavior
+selected by the validation report rather than revisiting those decisions during the
+migration.
+
+Do not start this plan merely because the ordinary Bun, Vite, or Expo happy path works.
+The gate includes the difficult workspace results, client artifact inspection, shared
+package behavior, secret-store workflow, and scaffold-selection matrix from Plan 17.
+
+## Decision
+
+Before changing production paths, add an ADR under `docs/template/adr/` that records:
+
+- why the template adopts Varlock instead of maintaining a Metaideas env package;
+- the chosen schema ownership model for application and package workspaces;
+- how sensitive, non-sensitive, build-time, and runtime values are represented;
+- which secret-store behavior is supported by default versus left to scaffold owners;
+- Convex's native environment subsystem as an intentional independent exception, plus
+  accepted adapters for WXT, Expo configuration, Tauri, or other deployment-owned
+  runtimes;
+- how `.env.schema`, local overrides, generated TypeScript, and deployment platforms
+  divide ownership;
+- why global environment type augmentation remains disabled.
+
+Treat this as an upstream template decision. Scaffold owners may replace Varlock later,
+but a newly scaffolded project must receive one coherent environment system.
+
+## 1. Establish dependency and tooling topology
+
+Install the validated Varlock version and only the integration packages required by
+selected application workspaces. Keep framework integrations in the workspaces that
+configure their bundlers instead of making every workspace depend on Expo, Vite,
+Astro, or a deployment adapter.
+
+Apply the validated Bun strategy:
+
+- disable Bun's automatic env loading globally only if Plan 17 proved all repository
+  commands remain correct;
+- otherwise wrap Varlock-managed commands or use the appropriate Bun flag;
+- prevent two loaders with different precedence rules from populating the same process.
+
+Add repository scripts for environment validation and generated types. Integrate them
+with Turbo so code generation happens before type checking/building and deployment
+validation is not incorrectly cached. Declare relevant environment inputs or pass-
+through values so Turbo neither serves stale outputs nor invalidates every task for
+unrelated secrets.
+
+Pin or constrain generated artifacts according to the validation decision. If generated
+TypeScript is committed, require deterministic regeneration and a clean-tree CI check.
+If it is ignored, ensure setup, install, check, editor startup, and targeted builds all
+produce it before TypeScript needs it.
+
+## 2. Introduce package-owned contracts and application schemas
+
+Implement the schema ownership model selected in Plan 17. The expected default is:
+
+- a package workspace owns reusable contract fragments under `env/`, using only the
+  applicable names `shared.env`, `client.env`, `server.env`, and `build.env`;
+- package surface contracts remain flat files such as `env/server.env`, not
+  `env/preset.env` or nested `env/server/.env.schema` directories;
+- it generates a package-local typed `ENV` module for internal imports;
+- an application workspace owns the complete resolved graph for its process or bundle;
+- the application root `.env.schema` imports the relevant surface contracts for
+  selected packages and adds its own keys;
+- tooling-only values are declared by the workspace or command that consumes them.
+
+Apply these surface meanings consistently:
+
+- `shared.env`: non-sensitive values used across runtimes;
+- `client.env`: values explicitly permitted in browser or native bundles;
+- `server.env`: server-runtime values, including sensitive values;
+- `build.env`: values consumed by build, upload, or deployment tooling and never by a
+  client runtime.
+
+Packages create only the surfaces they need. Do not create empty files merely to fill
+all four slots, and do not introduce framework-specific surfaces unless Plan 17 proves
+that an existing contract cannot be represented by the standard vocabulary. A package
+root `.env.schema` may compose its surfaces for package-owned commands and local type
+generation, but root policy stays out of reusable surface files.
+
+Migrate every Varlock-owned preset and declaration, including auth/providers, database,
+Inngest, KV, Portless, Resend, S3, Sentry variants, Stripe, PostHog, and Tauri. Migrate
+the Convex backend separately to its native environment declaration and generated
+`env` API. Preserve current coercion and validation unless Plan 17 explicitly accepted
+a behavior change. Add descriptions and sensitivity metadata while the ownership
+context is clear.
+
+Avoid a new central schema dumping ground. Keep a small shared environment workspace
+only if it provides a real reusable contract or command boundary after package-owned
+schemas are in place. Do not retain `@init/env` solely to preserve its name.
+
+Each application schema must be readable as its complete environment contract. Use
+explicit imports, do not require keys for packages omitted from that application, and
+keep environment selection consistent across workspaces.
+
+The intended layout is:
+
+```text
+packages/db/
+├── env/
+│   └── server.env
+├── .env.schema
+└── src/
+    ├── env.generated.ts
+    └── env.ts
+
+packages/observability/
+├── env/
+│   ├── shared.env
+│   ├── client.env
+│   ├── server.env
+│   └── build.env
+└── .env.schema
+
+apps/api/
+├── .env.schema
+└── src/shared/
+    ├── env.generated.ts
+    └── env.ts
+```
+
+## 3. Replace runtime env APIs
+
+Generate local TypeScript modules with `exposeEnv=local` and environment augmentation
+disabled. Keep application-facing imports stable where useful:
+
+```ts
+import { env } from "#shared/env.ts"
+```
+
+The handwritten `env.ts` may re-export the generated `ENV`, but it must not reconstruct
+`process.env`, merge `import.meta.env`, or run a second validation library.
+
+Update shared packages to import their package-local generated environment module or
+receive explicit configuration, following the ownership decision. Remove imports of
+resolved preset objects such as `db`, `resend`, `stripe`, `kv`, and `sentry` from
+`@init/env/presets`.
+
+Replace direct application accesses to project-defined `process.env` and
+`import.meta.env` with typed `ENV` access. Retain framework-owned flags such as
+`import.meta.env.DEV` only when they are not project configuration and the framework
+contract remains the correct owner. Keep necessary compatibility access in deployment
+configuration files only when documented by the ADR.
+
+## 4. Integrate each application workspace
+
+Apply the framework path proven by Plan 17:
+
+- `apps/api`: Bun/JavaScript initialization and command wrapping;
+- `apps/app`: Varlock's Vite or deployment-specific TanStack Start integration;
+- `apps/web` and `apps/docs`: the Astro integration appropriate to their adapters;
+- `apps/mobile`: Babel and Metro integration composed with Sentry and Uniwind;
+- `apps/desktop`: Vite integration with Tauri-provided build variables;
+- `apps/extension`: the validated WXT/Vite adapter;
+- `packages/backend`: Convex-native declarations in `convex.config.ts`, generated typed
+  `env` access, and local parsing without Varlock runtime or synchronization.
+
+Remove `@tooling/env/vite` after all consumers use their framework integration. Remove
+`getRuntimeEnv()` and prefix constants when no remaining caller needs them. Do not use
+public prefixes as the security boundary; sensitivity metadata and framework
+integration own that boundary. Retain prefixes temporarily only where migration,
+third-party tooling, or platform conventions make them valuable.
+
+Preserve bundler/plugin ordering established by the validation spike. Add focused tests
+or configuration assertions around integrations whose order is security- or
+correctness-sensitive.
+
+## 5. Implement deployment and secret-store workflows
+
+Add the provider-neutral Varlock workflow proven in Plan 17. Document how a scaffold
+owner can use plain platform secrets or configure a supported secret store. Do not make
+a maintainer's personal vault, organization, item identifiers, or account topology part
+of the template.
+
+For the validated reference provider, include:
+
+- schema reference examples without real identifiers or values;
+- local login/setup instructions;
+- non-interactive CI authentication and secret-zero handling;
+- development, preview, and production separation;
+- rotation and access-denied recovery;
+- redaction expectations and artifact checks.
+
+Implement the accepted deployment paths for EAS, server hosting, static builds, and any
+worker adapter in the repository. Validation must happen before mutation of a remote
+deployment. Secret synchronization commands must identify their target environment
+explicitly and must not print resolved values.
+
+Keep Convex runtime values in Convex's deployment environment and manage them through
+its native dashboard, CLI, project defaults, and deploy-key workflow. Do not synchronize
+Varlock-resolved secrets into Convex. Document Convex deployment values and deploy keys
+as a separate operational boundary, while consuming applications continue to manage
+their non-sensitive Convex URLs through their own Varlock schemas.
+
+## 6. Replace `.env.template` and update template commands
+
+Make `.env.schema` the authoritative list of keys, types, requirements, sensitivity,
+descriptions, and safe defaults. Decide from the validation result whether local
+development value files remain copy-once template recipes or are generated/resolved by
+Varlock.
+
+Update every template command that currently edits `.env.template`, especially backend
+connection flows. Commands must compose or remove schema imports and application-owned
+keys idempotently when workspaces are selected, connected, disconnected, or omitted.
+Avoid string insertion that can silently duplicate decorators or leave a schema import
+pointing to a removed workspace.
+
+Migrate the environment branch of `turbo/generators/commands/code-snippets.ts` to add
+package-owned contract fragments and application schema imports under the selected
+ownership model, or remove the branch if Varlock makes those snippets unnecessary.
+Remove `templates/code-snippets/environment-presets.ts.hbs` when it no longer has a
+consumer; the command must not read or modify the deleted `packages/env/src/presets.ts`.
+
+Update internal cleanup paths and dependency removal so a scaffolded project retains
+only the integrations, schemas, scripts, and generated modules needed by its selected
+workspaces. Ensure removing a package also removes its contract import without removing
+similarly named application-owned keys.
+
+Delete obsolete `.env.template` files only after all documentation, template commands,
+and local setup flows use the replacement. If a value template remains for convenient
+local defaults, generate or audit it from the schema so it cannot become a second
+contract.
+
+## 7. Add tests and security assertions
+
+Add focused tests alongside custom adapters and template commands. Cover:
+
+- package contract composition and removal;
+- deterministic local type generation without global augmentation;
+- required/optional/default behavior across development, test, preview, and production;
+- parsed arrays, booleans, numbers, URLs, and constrained strings;
+- application schemas containing exactly the selected package contracts;
+- Convex-native required-variable validation, generated `env` types, local parsing, and
+  coexistence with Varlock-managed consuming applications;
+- WXT and Expo integration configuration;
+- failure before build/deploy when a required value is missing;
+- redaction and deliberate canary-secret rejection.
+
+Add artifact inspection for representative mobile, extension, web, desktop, and source-
+map outputs. Use synthetic canary values only. Tests must fail when a sensitive canary
+appears in a client artifact, generated file, snapshot, or captured log.
+
+## 8. Remove the old implementation
+
+Once every caller has migrated:
+
+- remove `@t3-oss/env-core`;
+- remove `packages/env/src/runtime.ts`, T3-based presets, constants, reset declarations,
+  and obsolete Vite env declarations;
+- remove `std-env` dependencies that existed only for runtime env merging or
+  `skipValidation`;
+- remove `@tooling/env` if it has no remaining responsibility;
+- remove Zod/schema imports used only for environment validation while preserving the
+  shared schema utilities used elsewhere;
+- clean package exports, dependency declarations, Turbo env lists, TypeScript includes,
+  and Adamantite/Knip configuration.
+
+Do not leave a compatibility wrapper that validates twice or presents stale T3 Env
+semantics over Varlock. A short-lived migration shim is acceptable only within this
+plan and must be removed before completion.
+
+## 9. Document the scaffold-owner experience
+
+Update root and workspace documentation with:
+
+- where application and package contracts live;
+- how to add, rename, deprecate, or remove a key;
+- how to mark a value sensitive, non-sensitive, dynamic, required, or environment-
+  specific;
+- how to regenerate types and validate locally;
+- how development, tests, CI, preview, and production select values;
+- how to configure a secret store without committing resolved values;
+- framework-specific notes for Expo/EAS, WXT, Tauri, Astro, and TanStack Start;
+- the independent Convex environment workflow, including native declarations,
+  deployment values, generated `.env.local` outputs, deploy keys, and consuming
+  application URLs;
+- how template commands modify contracts after workspace selection.
+
+Replace documentation that tells users to compare `.env.local` with `.env.template`.
+Explain that client availability is explicit sensitivity/bundling metadata, not proof
+that a value is secret merely because it lacks a public prefix.
+
+## 10. Verify complete and scaffolded repository shapes
+
+Run repository-wide formatting, checks, dependency analysis, monorepo consistency, and
+tests. Build each selected application with synthetic valid environments and assert
+expected failures with incomplete production environments.
+
+Repeat the scaffold matrix from Plan 17 using the real template commands. For each
+shape, verify setup from a clean clone, type generation, editor-visible types, local
+development startup, targeted builds, and the absence of dangling schema imports or
+unused integration dependencies.
+
+Plan 18 is complete only when the old env system is removed, all supported deployment
+boundaries have one documented path, and client artifact scans pass.
+
+## Verification
+
+```sh
+bun run format
+bun run check
+bun run analyze
+bun run check:monorepo
+bun test
+bun run env:check
+bun run codegen
+bun run build
+```
+
+Also run the deployment-specific dry runs, EAS/Convex checks, artifact scans, and
+disposable scaffold matrix recorded by Plan 17. Commands requiring external credentials
+must use test projects and synthetic secrets, and their successful evidence must be
+captured without recording secret values.


### PR DESCRIPTION
## Summary

- add a gated validation plan for evaluating Varlock across init
- define flat package-owned environment surfaces and application-owned composition roots
- validate Expo/EAS, WXT, Tauri, shared package composition, secret stores, CI, and scaffold selection
- treat Convex as an independent native environment subsystem
- add a follow-up implementation plan that starts only after the validation gate passes

## Why

Varlock appears to cover init's environment validation, generated types, client/server protection, pre-deployment checks, and secret-store integration without requiring a new Metaideas OSS package. The difficult workspace boundaries need evidence before replacing T3 Env, so the implementation plan is explicitly gated by a Pass or accepted Conditional pass from the validation plan.

## Impact

This PR changes planning documentation only. It does not alter runtime environment handling, dependencies, application builds, or deployment behavior.

## Validation

- `bun run format`
- `bun run codegen`
- `bun run check`
- `git diff --check`
