### PR TITLE
chore: bump bun base image to 1.3.14

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,5 @@
 # Base image with Bun
-FROM oven/bun:1.2.16 AS base
+FROM oven/bun:1.3.14 AS base
 
 # Install turbo CLI globally using Bun
 FROM base AS turbo-cli


### PR DESCRIPTION
Upgrades the base Docker image for the API from `oven/bun:1.2.16` to `oven/bun:1.3.14`.