### PR TITLE
chore: replace `qte` with `humanspan`

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,7 +37,7 @@
     "hono": "4.12.32",
     "hono-openapi": "^1.3.1",
     "hono-rate-limiter": "0.5.3",
-    "qte": "0.1.1",
+    "humanspan": "0.2.0",
     "superjson": "2.2.6",
     "varlock": "1.16.0"
   },

--- a/apps/api/src/shared/middleware.ts
+++ b/apps/api/src/shared/middleware.ts
@@ -3,7 +3,7 @@ import { rateLimiter } from "hono-rate-limiter"
 import { createMiddleware } from "hono/factory"
 import { HTTPException } from "hono/http-exception"
 import { languageDetector } from "hono/language"
-import { type TimeExpression, ms } from "qte"
+import { type TimeExpression, ms } from "humanspan"
 import type { AppContext, AuthenticatedAppContext } from "#shared/types.ts"
 import { baseLocale, locales } from "#shared/internationalization/runtime.js"
 

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
         "hono": "4.12.32",
         "hono-openapi": "^1.3.1",
         "hono-rate-limiter": "0.5.3",
-        "qte": "0.1.1",
+        "humanspan": "0.2.0",
         "superjson": "2.2.6",
         "varlock": "1.16.0",
       },
@@ -297,7 +297,7 @@
         "@better-auth/expo": "1.6.25",
         "better-auth": "1.6.25",
         "drizzle-orm": "0.45.2",
-        "qte": "0.1.1",
+        "humanspan": "0.2.0",
       },
       "devDependencies": {
         "@tooling/tsconfig": "workspace:*",
@@ -362,7 +362,7 @@
         "@react-email/components": "1.0.12",
         "@react-email/render": "2.1.0",
         "date-fns": "4.1.0",
-        "qte": "0.1.1",
+        "humanspan": "0.2.0",
         "resend": "6.7.0",
         "varlock": "1.16.0",
       },
@@ -3159,6 +3159,8 @@
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
+    "humanspan": ["humanspan@0.2.0", "", {}, "sha512-QS1z1G+XIyjkOGbWjRgnhUd8tMEF59UtHg4zR8BCDZkUEp1JLpTpZkOzLJSXOruVjO5poLt4z4X8Mx1w+dLOTw=="],
+
     "hyphenate-style-name": ["hyphenate-style-name@1.1.0", "", {}, "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="],
 
     "i18next": ["i18next@26.3.6", "", { "peerDependencies": { "typescript": "^5 || ^6 || ^7" }, "optionalPeers": ["typescript"] }, "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA=="],
@@ -3928,8 +3930,6 @@
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
-
-    "qte": ["qte@0.1.1", "", {}, "sha512-zaRCcV+OxZhHbH8YskzrPy9BEQJaYyvbV/p9IdofzZp7b0ksBnv8edLb9Lv+7zlKsGpPBqFdui5XV+p6aArNug=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -27,7 +27,7 @@
     "@better-auth/expo": "1.6.25",
     "better-auth": "1.6.25",
     "drizzle-orm": "0.45.2",
-    "qte": "0.1.1"
+    "humanspan": "0.2.0"
   },
   "devDependencies": {
     "@tooling/tsconfig": "workspace:*",

--- a/packages/auth/src/constants.ts
+++ b/packages/auth/src/constants.ts
@@ -1,4 +1,4 @@
-import { seconds } from "qte"
+import { seconds } from "humanspan"
 
 export const AUTH_COOKIE_PREFIX = "init"
 export const AUTH_APP_NAME = "init"

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -24,7 +24,7 @@
     "@react-email/components": "1.0.12",
     "@react-email/render": "2.1.0",
     "date-fns": "4.1.0",
-    "qte": "0.1.1",
+    "humanspan": "0.2.0",
     "resend": "6.7.0",
     "varlock": "1.16.0"
   },

--- a/packages/email/src/client.ts
+++ b/packages/email/src/client.ts
@@ -4,7 +4,7 @@ import { getLogger, LoggerCategory } from "@init/observability/logger"
 import { singleton } from "@init/utils/singleton"
 import { render } from "@react-email/render"
 import { addMilliseconds } from "date-fns"
-import { type TimeExpression, ms } from "qte"
+import { type TimeExpression, ms } from "humanspan"
 import { Resend } from "resend"
 import { ENV } from "./env.generated.ts"
 


### PR DESCRIPTION
Replace the `qte` dependency with `humanspan` across all packages (`api`, `auth`, and `email`). The `humanspan` package (v0.2.0) serves as a drop-in replacement for `qte` (v0.1.1), providing the same `ms`, `seconds`, and `TimeExpression` utilities for time expression handling.