### PR TITLE
chore: distinguish docs favicon from web and pad the spiral

### DIFF
--- a/apps/docs/public/favicon.svg
+++ b/apps/docs/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <rect width="128" height="128" rx="28" fill="#080a0d"/>
-  <path transform="translate(64 64) rotate(45) scale(.78) translate(-64 -64)" d="M64 64h20v20H44V44h60v60H24V24h80" fill="none" stroke="#f1f3f5" stroke-width="13" stroke-linecap="square" stroke-linejoin="miter"/>
+  <rect width="128" height="128" rx="28" fill="#f1f3f5"/>
+  <path transform="translate(64 64) rotate(45) scale(.68) translate(-64 -64)" d="M64 64h20v20H44V44h60v60H24V24h80" fill="none" stroke="#080a0d" stroke-width="13" stroke-linecap="square" stroke-linejoin="miter"/>
 </svg>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
   <rect width="128" height="128" rx="28" fill="#080a0d"/>
-  <path transform="translate(64 64) rotate(45) scale(.78) translate(-64 -64)" d="M64 64h20v20H44V44h60v60H24V24h80" fill="none" stroke="#f1f3f5" stroke-width="13" stroke-linecap="square" stroke-linejoin="miter"/>
+  <path transform="translate(64 64) rotate(45) scale(.68) translate(-64 -64)" d="M64 64h20v20H44V44h60v60H24V24h80" fill="none" stroke="#f1f3f5" stroke-width="13" stroke-linecap="square" stroke-linejoin="miter"/>
 </svg>


### PR DESCRIPTION
The web and docs favicons were identical — a white spiral on a black rounded square — so the two sites were indistinguishable in browser tabs. The spiral also ran close to the square's corners.

Docs is now inverted to a black spiral on a white background, while web keeps the white-on-black look. Both spirals are scaled down from 0.78 to 0.68 so there's more breathing room between the spiral and the rounded-square edges.

*Changes made by Claude Fable 5 via Claude Code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)