### PR TITLE
ci: pin pullfrog action to v0.1.57 until 0.1.58 ships on npm

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -26,7 +26,10 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run agent
-        uses: pullfrog/pullfrog@v0
+        # TODO: adelrodriguez -- Temporarily pinned: the v0 tag resolves to v0.1.58,
+        # which runs `npx pullfrog@^0.1.58`, but 0.1.58 was never published to npm
+        # (latest is 0.1.57). Restore @v0 once upstream publishes.
+        uses: pullfrog/pullfrog@v0.1.57
         with:
           prompt: ${{ inputs.prompt }}
         env:


### PR DESCRIPTION
Pullfrog reviews are currently failing at startup with `npm error notarget No matching version found for pullfrog@^0.1.58`. The action's floating `v0` tag points at `v0.1.58`, whose bootstrap runs `npx pullfrog@^<action version>` — but `0.1.58` exists only as a git tag upstream; the npm registry's latest publish is `0.1.57`.

This pins `uses: pullfrog/pullfrog@v0.1.57`, whose bootstrap requests `^0.1.57` and resolves cleanly. A TODO comment marks it for reverting to `@v0` once upstream publishes `0.1.58`.

Since the workflow is `workflow_dispatch`-triggered from the default branch, this needs to merge to main to unblock reviews on open PRs (e.g. #144).

Changes made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)